### PR TITLE
Set ColorAuthority for AVIF ICC/CICP precedence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "almost-enough"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c8f3e651142e773f3eab1b8314ade013d5a3eef6dc2cd2af6dad9b0ede58f23"
+checksum = "a2040cad221332dbe816267e6f2b55032f53a297ceb4d97f8e612df471aa6dbc"
 dependencies = [
  "enough",
 ]
@@ -454,9 +454,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "enough"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521236efef7dcf4a95af2976e34b5b10780e8747eb78fa4742aa65b2ee189222"
+checksum = "f8e1bd41ecce82c300d0c84fa35b080fa6db50a5398b18f1abf0357bb067549e"
 
 [[package]]
 name = "env_filter"
@@ -1981,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "zencodec"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882aeed23dcf360faded3a50b468b3bc6226da46b2d62e39d72f98f68bb6835b"
+checksum = "b86a563becc403bb3e98225c5715711b87cd1c32222659b7d84282c4f5800fe3"
 dependencies = [
  "almost-enough",
  "enough",
@@ -1993,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "zenpixels"
-version = "0.2.3"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94439a80006e7c0667781a60ebb73145db6e6792e546f187933bcc472b36dece"
+checksum = "a39c7b3b7b7881f6689a556ef3ab1245c1cec2f39f2cd919d92e6ce3d7dcd530"
 dependencies = [
  "bytemuck",
  "imgref",
@@ -2005,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "zenpixels-convert"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c25c281f90e40c16b02eb7329b8800db9f225891e19f62d4b9a53ec9068c1a0"
+checksum = "d6008b9c56f8377ba7a973f53bb498c3137aec51da56897ee5fa18c210f1be13"
 dependencies = [
  "archmage",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,10 @@ ravif = { package = "zenravif", version = "0.1.1", default-features = false, opt
 # svtav1: disabled — produces corrupt bitstreams in most configurations (see svtav1-rs README)
 # svtav1 = { path = "/home/lilith/work/svtav1/svtav1-rs/svtav1", version = "0.1.0", optional = true }
 almost-enough = { version = "0.4.3", default-features = false }
-zencodec = { version = "0.1.13", optional = true }
+zencodec = { version = "0.1.16", optional = true }
 # zennode = { path = "../zennode/zennode", optional = true, default-features = false, features = ["derive"] }
-zenpixels = { version = "0.2.2", default-features = false, features = ["imgref", "rgb"] }
-zenpixels-convert = { version = "0.2.2", default-features = false, features = ["rgb"] }
+zenpixels = { version = "0.2.7", default-features = false, features = ["imgref", "rgb"] }
+zenpixels-convert = { version = "0.2.7", default-features = false, features = ["rgb"] }
 linear-srgb = { version = "0.6.7"}
 
 [dev-dependencies]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -30,7 +30,7 @@ use zencodec::encode::EncodeOutput;
 use zencodec::{
     GainMapPresence, ImageFormat, ImageInfo, ImageSequence, ResourceLimits, Supplements,
 };
-use zenpixels::{ChannelType, PixelBuffer, PixelDescriptor, PixelSlice};
+use zenpixels::{ChannelType, ColorAuthority, PixelBuffer, PixelDescriptor, PixelSlice};
 use zenpixels_convert::PixelBufferConvertTypedExt as _;
 
 use crate::error::Error;
@@ -2234,6 +2234,10 @@ fn convert_native_info(native: &crate::image::ImageInfo) -> ImageInfo {
 
     if let Some(ref icc) = native.icc_profile {
         info = info.with_icc_profile(icc.clone());
+        // authority stays Icc (default) — ICC > nclx per MIAF spec
+    } else {
+        // No ICC → CICP (from nclx or AV1 SPS) is authoritative
+        info = info.with_color_authority(ColorAuthority::Cicp);
     }
     if let Some(ref exif) = native.exif {
         info = info.with_exif(exif.clone());


### PR DESCRIPTION
## Summary

- Sets `ColorAuthority::Cicp` when no ICC profile is present in `convert_native_info()`
- AVIF/MIAF spec defines ICC > nclx > AV1 SPS CICP precedence; CICP is always populated from nclx or AV1 SPS fallback, so when ICC is absent CICP is the authoritative color description
- When ICC is present, authority remains `Icc` (the default) — no behaviour change for ICC-bearing files

## Depends on

- imazen/zencodec#8
- imazen/zenpixels#4

## Test plan

- [ ] `cargo check --features zencodec` passes
- [ ] Decode an ICC-bearing AVIF: `color_authority` should be `Icc`
- [ ] Decode an AVIF without ICC (nclx-only): `color_authority` should be `Cicp`