### PR TITLE
feat(expert): __expert + InternalParams mirroring zenravif

### DIFF
--- a/.github/actions/clone-ravif/action.yml
+++ b/.github/actions/clone-ravif/action.yml
@@ -25,6 +25,21 @@ runs:
         if [ ! -d ravif ]; then
           git clone --depth 1 https://github.com/imazen/cavif-rs.git ravif
         fi
+    # TEMPORARY (zenavif PR #9): the `__expert` work depends on an
+    # unpublished zenravif 0.1.3 living on the cavif-rs branch
+    # `feat/expert-internal-params`. The active [patch.crates-io] block
+    # in zenavif's Cargo.toml points at `../ravif--expert/ravif`, so we
+    # must also clone that branch into a sibling directory. Once
+    # cavif-rs#1 merges and zenravif 0.1.3 is published, drop both this
+    # step and the patch block in Cargo.toml.
+    - name: Clone imazen/cavif-rs (feat/expert-internal-params) into ../ravif--expert
+      shell: bash
+      run: |
+        cd ..
+        if [ ! -d ravif--expert ]; then
+          git clone --depth 1 --branch feat/expert-internal-params \
+            https://github.com/imazen/cavif-rs.git ravif--expert
+        fi
     - name: Clone imazen/zenanalyze into ../zenanalyze
       shell: bash
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ the [zenrav1e](https://github.com/imazen/zenrav1e) encoder (our fork of
 
 ## [Unreleased]
 
+### Added
+- New `__expert` cargo feature exposing `expert::InternalParams`, an
+  `Option<T>` struct of speed-preset overrides for the 4 deepest
+  content-dependent knobs (`partition_range`, `complex_prediction_modes`,
+  `lrf`, `fast_deblock`). Apply via
+  `EncoderConfig::with_internal_params(InternalParams)`.
+  `#[non_exhaustive]` + `Default` so callers tolerate field additions
+  in any patch. Each `None` keeps the speed preset's default; each
+  `Some(_)` overrides. Implies `encode-imazen` and pulls
+  `ravif/__expert` for the underlying overrides. Used by the rav1e
+  knob predictor MLP training harness; not for production code.
+
+### Changed
+- The 4 individual setters (`with_partition_range`,
+  `with_complex_prediction_modes`, `with_lrf`, `with_fast_deblock`)
+  added in Phase 0.5 are removed from the public API in favour of
+  `with_internal_params(InternalParams)`. Never published, so no
+  deprecation cycle. The other 11 `encode-imazen`-gated setters
+  (`with_qm`, `with_vaq`, `with_seg_boost`, `with_cdef`, etc.) stay
+  as-is — they're already in 0.1.6 published.
+- `predictor_sweep` and `phase2_oat` examples now require the
+  `__expert` feature (was `encode-imazen`).
+
 ### Changed
 - Bumped baked picker artifacts to `v0_1_1`: re-baked from a 4× larger
   Phase 1a corpus (448 images / 89,601 sweep rows vs. 116 / 23,200 in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ the [zenrav1e](https://github.com/imazen/zenrav1e) encoder (our fork of
   `Some(_)` overrides. Implies `encode-imazen` and pulls
   `ravif/__expert` for the underlying overrides. Used by the rav1e
   knob predictor MLP training harness; not for production code.
+- Theory-of-operation docs on every `InternalParams` field covering
+  the AV1 pipeline stage, why a caller might override it, the
+  underlying mechanism, and the speed-preset interaction. Cross-
+  references `zenravif::expert::InternalParams` for source-line
+  citations into zenrav1e.
+- `tests/expert_internal_params.rs` — 12 permutation, idempotency,
+  combined-knob, default-as-baseline, reset, and forwarding-parity
+  tests for `InternalParams`. Verifies that zenavif's wrapper produces
+  byte-identical output to calling `zenravif::Encoder::with_internal_params`
+  directly with the same values. Gated on `__expert`.
 
 ### Changed
 - The 4 individual setters (`with_partition_range`,
@@ -31,7 +41,18 @@ the [zenrav1e](https://github.com/imazen/zenrav1e) encoder (our fork of
   (`with_qm`, `with_vaq`, `with_seg_boost`, `with_cdef`, etc.) stay
   as-is — they're already in 0.1.6 published.
 - `predictor_sweep` and `phase2_oat` examples now require the
-  `__expert` feature (was `encode-imazen`).
+  `__expert` feature (was `encode-imazen`); `phase2_oat`'s deep-knob
+  perturbations rebuild on top of `ravif::expert::InternalParams`
+  rather than the removed individual setters.
+- `partition_range` doc and tests now reflect that zenrav1e
+  debug-asserts `max <= 64×64`; `128` is invalid (would panic in
+  debug builds). Valid values: `{4, 8, 16, 32, 64}`.
+
+### Build
+- `[patch.crates-io] zenravif` temporarily points at
+  `../ravif--expert/ravif` while ravif's `feat/expert-internal-params`
+  branch is unmerged. Revert to `../ravif/ravif` once that branch
+  lands; remove the patch entirely once zenravif 0.1.3 publishes.
 
 ### Changed
 - Bumped baked picker artifacts to `v0_1_1`: re-baked from a 4× larger

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,10 @@ rustdoc-args = ["--generate-link-to-definition"]
 
 # Temporary patch — pulls in unpublished zenravif 0.1.3 with the 4
 # deep-knob overrides used by the rav1e knob predictor MLP training
-# harness (see docs/RAV1E_PICKER_PLAN.md). Remove once zenravif 0.1.3
-# is published to crates.io.
+# harness (see docs/RAV1E_PICKER_PLAN.md). While ravif's
+# `feat/expert-internal-params` branch is unmerged, the patch points
+# at the sibling worktree path; revert to `../ravif/ravif` once that
+# branch lands. Remove the patch entirely once zenravif 0.1.3 is on
+# crates.io.
 [patch.crates-io]
-zenravif = { path = "../ravif/ravif" }
+zenravif = { path = "../ravif--expert/ravif" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,11 +118,11 @@ required-features = ["encode-imazen", "encode-threading"]
 
 [[example]]
 name = "predictor_sweep"
-required-features = ["encode-imazen"]
+required-features = ["__expert"]
 
 [[example]]
 name = "phase2_oat"
-required-features = ["encode-imazen"]
+required-features = ["__expert"]
 
 [[example]]
 name = "auto_tune_smoke"
@@ -140,6 +140,12 @@ encode-asm = ["encode", "ravif/asm"]
 encode-threading = ["encode", "ravif/threading"]
 # Encoding with imazen/zenrav1e fork features (QM, VAQ, still-image tuning, lossless)
 encode-imazen = ["encode", "ravif/imazen"]
+# Expert / unstable: exposes `InternalParams` for codec calibration sweeps
+# + the rav1e knob predictor MLP training pipeline. Double-underscore prefix
+# signals "private — do not depend on this in production code." Anything
+# in the `expert` module may change without semver bumps. Pulls zenravif's
+# `__expert` feature for the underlying speed-preset overrides.
+__expert = ["encode-imazen", "ravif/__expert"]
 # Auto-tune via the rav1e knob predictor MLP. Includes a baked ZNPR
 # model + zenanalyze feature extractor; adds ~30 KB to the binary.
 # See docs/RAV1E_PICKER_PLAN.md for the training pipeline.

--- a/examples/extract_features_natural.rs
+++ b/examples/extract_features_natural.rs
@@ -260,13 +260,7 @@ fn main() -> ExitCode {
             write!(
                 w_lock,
                 "\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-                entry.axis_class,
-                entry.source,
-                entry.relative_path,
-                size_class,
-                size_bucket,
-                w,
-                h
+                entry.axis_class, entry.source, entry.relative_path, size_class, size_bucket, w, h
             )
             .ok();
             for c in &cols {

--- a/examples/extract_features_natural.rs
+++ b/examples/extract_features_natural.rs
@@ -48,7 +48,9 @@ struct ManifestEntry {
     relative_path: String,
     axis_class: String,
     source: String,
+    #[allow(dead_code)]
     width: u32,
+    #[allow(dead_code)]
     height: u32,
 }
 

--- a/examples/phase2_oat.rs
+++ b/examples/phase2_oat.rs
@@ -79,19 +79,40 @@ fn perturbations() -> Vec<Pert> {
         ("encode_bottomup", "on", |e| {
             e.with_encode_bottomup(Some(true))
         }),
-        // Deep knobs (newly plumbed)
+        // Deep knobs (zenravif __expert / InternalParams).
+        // Each closure builds a fresh InternalParams (so combinations
+        // don't leak between perturbations) and forwards via
+        // ravif::Encoder::with_internal_params.
         ("partition_range", "fine_4_16", |e| {
-            e.with_partition_range(Some((4, 16)))
+            let mut p = ravif::expert::InternalParams::default();
+            p.partition_range = Some((4, 16));
+            e.with_internal_params(p)
         }),
         ("partition_range", "coarse_16_64", |e| {
-            e.with_partition_range(Some((16, 64)))
+            let mut p = ravif::expert::InternalParams::default();
+            p.partition_range = Some((16, 64));
+            e.with_internal_params(p)
         }),
         ("complex_prediction_modes", "on", |e| {
-            e.with_complex_prediction_modes(Some(true))
+            let mut p = ravif::expert::InternalParams::default();
+            p.complex_prediction_modes = Some(true);
+            e.with_internal_params(p)
         }),
-        ("lrf", "off", |e| e.with_lrf(Some(false))),
-        ("lrf", "on", |e| e.with_lrf(Some(true))),
-        ("fast_deblock", "on", |e| e.with_fast_deblock(Some(true))),
+        ("lrf", "off", |e| {
+            let mut p = ravif::expert::InternalParams::default();
+            p.lrf = Some(false);
+            e.with_internal_params(p)
+        }),
+        ("lrf", "on", |e| {
+            let mut p = ravif::expert::InternalParams::default();
+            p.lrf = Some(true);
+            e.with_internal_params(p)
+        }),
+        ("fast_deblock", "on", |e| {
+            let mut p = ravif::expert::InternalParams::default();
+            p.fast_deblock = Some(true);
+            e.with_internal_params(p)
+        }),
     ]
 }
 
@@ -353,7 +374,7 @@ fn main() -> ExitCode {
 
     pool.install(|| {
         manifest.par_iter().for_each(|entry| {
-            let dyn_img = match ImageReader::open(&entry.path).and_then(|r| Ok(r.decode())) {
+            let dyn_img = match ImageReader::open(&entry.path).map(|r| r.decode()) {
                 Ok(Ok(img)) => img,
                 _ => {
                     eprintln!("skip (decode fail): {}", entry.path.display());
@@ -374,7 +395,7 @@ fn main() -> ExitCode {
                     let mut w = writer.lock().unwrap();
                     writeln!(
                         w,
-                        "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.6}\t{:.2}",
+                        "{}\t{}\t{}\t{}\t{}\t{}\t{}\tbaseline\tdefault\t{}\t{:.6}\t{:.2}",
                         entry.path.display(),
                         sz,
                         img.width(),
@@ -382,8 +403,6 @@ fn main() -> ExitCode {
                         entry.sha256,
                         entry.content_class,
                         entry.source,
-                        "baseline",
-                        "default",
                         o.bytes,
                         o.zensim,
                         o.encode_ms,
@@ -414,8 +433,9 @@ fn main() -> ExitCode {
                                 o.encode_ms,
                             )
                             .ok();
-                            if total_done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) % 50
-                                == 0
+                            if total_done
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                                .is_multiple_of(50)
                             {
                                 w.flush().ok();
                                 eprintln!(

--- a/examples/predictor_sweep.rs
+++ b/examples/predictor_sweep.rs
@@ -733,13 +733,20 @@ fn encode_one(
     if bottomup_on {
         enc = enc.with_encode_bottomup(Some(true));
     }
-    if lrf_on {
-        enc = enc.with_lrf(Some(true));
-    }
-    match partition_range_idx {
-        -1 => enc = enc.with_partition_range(Some((4, 16))),
-        1 => enc = enc.with_partition_range(Some((16, 64))),
-        _ => {}
+    // The 4 deepest knobs (lrf, partition_range, complex_prediction_modes,
+    // fast_deblock) live behind ravif's `__expert` feature now — apply
+    // via InternalParams instead of individual setters.
+    {
+        let mut params = ravif::expert::InternalParams::default();
+        if lrf_on {
+            params.lrf = Some(true);
+        }
+        match partition_range_idx {
+            -1 => params.partition_range = Some((4, 16)),
+            1 => params.partition_range = Some((16, 64)),
+            _ => {}
+        }
+        enc = enc.with_internal_params(params);
     }
     if let Some(n) = enc_threads {
         enc = enc.with_num_threads(Some(n));

--- a/examples/predictor_sweep.rs
+++ b/examples/predictor_sweep.rs
@@ -522,9 +522,7 @@ fn main() -> ExitCode {
 
     pool.install(|| {
         manifest.par_iter().for_each(|entry| {
-            let dyn_img = match ImageReader::open(&entry.path)
-                .and_then(|r| Ok(r.decode()))
-            {
+            let dyn_img = match ImageReader::open(&entry.path).map(|r| r.decode()) {
                 Ok(Ok(img)) => img,
                 _ => {
                     eprintln!("skip (decode fail): {}", entry.path.display());
@@ -652,7 +650,10 @@ fn main() -> ExitCode {
                                     decode_ms,
                                 )
                                 .ok();
-                                if total_done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) % 100 == 0 {
+                                if total_done
+                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                                    .is_multiple_of(100)
+                                {
                                     w.flush().ok();
                                     eprintln!(
                                         "[done={} attempts={} skipped={} failed={}]",
@@ -695,6 +696,7 @@ struct EncodeResult {
     decode_ms: f64,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn encode_one(
     img: Img<&[RGB8]>,
     speed: u8,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -565,36 +565,20 @@ impl EncoderConfig {
         self
     }
 
-    /// Override partition block-size range. `min` and `max` must each be
-    /// one of `{4, 8, 16, 32, 64, 128}` and `min <= max`. Smaller mins
-    /// help text/screen content; larger maxes help smooth photo content.
-    /// None = preset.
-    #[cfg(feature = "encode-imazen")]
-    pub fn with_partition_range(mut self, range: Option<(u8, u8)>) -> Self {
-        self.override_partition_range = range;
-        self
-    }
-
-    /// Override prediction modes. `Some(true)` = ComplexAll (slow, all
-    /// intra modes). `Some(false)` = Simple (fast). None = preset.
-    #[cfg(feature = "encode-imazen")]
-    pub fn with_complex_prediction_modes(mut self, enable: Option<bool>) -> Self {
-        self.override_complex_prediction_modes = enable;
-        self
-    }
-
-    /// Override loop restoration filter (Wiener / SGR). Helps smooth/noisy
-    /// content; can over-soften line art. None = preset.
-    #[cfg(feature = "encode-imazen")]
-    pub fn with_lrf(mut self, enable: Option<bool>) -> Self {
-        self.override_lrf = enable;
-        self
-    }
-
-    /// Override fast vs full deblock filter search. None = preset.
-    #[cfg(feature = "encode-imazen")]
-    pub fn with_fast_deblock(mut self, enable: Option<bool>) -> Self {
-        self.override_fast_deblock = enable;
+    /// Apply expert-only [`crate::expert::InternalParams`].
+    ///
+    /// **Unstable surface** — may change in any patch release; see
+    /// [`crate::expert`] module docs for the contract. Each `Some(_)`
+    /// field overrides a speed-preset default; each `None` leaves the
+    /// preset's value untouched. Calling this multiple times overwrites
+    /// previously-set fields wholesale (the struct is the unit of
+    /// configuration, not the individual fields).
+    #[cfg(feature = "__expert")]
+    pub fn with_internal_params(mut self, params: crate::expert::InternalParams) -> Self {
+        self.override_partition_range = params.partition_range;
+        self.override_complex_prediction_modes = params.complex_prediction_modes;
+        self.override_lrf = params.lrf;
+        self.override_fast_deblock = params.fast_deblock;
         self
     }
 
@@ -772,11 +756,21 @@ fn build_ravif_encoder(
             .with_sgr_full(config.override_sgr_full)
             .with_lru_on_skip(config.override_lru_on_skip)
             .with_segmentation_complex(config.override_segmentation_complex)
-            .with_encode_bottomup(config.override_encode_bottomup)
-            .with_partition_range(config.override_partition_range)
-            .with_complex_prediction_modes(config.override_complex_prediction_modes)
-            .with_lrf(config.override_lrf)
-            .with_fast_deblock(config.override_fast_deblock);
+            .with_encode_bottomup(config.override_encode_bottomup);
+        #[cfg(feature = "__expert")]
+        {
+            // The 4 deepest knobs live behind ravif's `__expert` feature.
+            // Mirror EncoderConfig's per-field overrides into ravif's
+            // InternalParams in one call. Build via Default + field
+            // assignment because `#[non_exhaustive]` prohibits struct
+            // literal construction outside the defining crate.
+            let mut params = ravif::expert::InternalParams::default();
+            params.partition_range = config.override_partition_range;
+            params.complex_prediction_modes = config.override_complex_prediction_modes;
+            params.lrf = config.override_lrf;
+            params.fast_deblock = config.override_fast_deblock;
+            enc = enc.with_internal_params(params);
+        }
         if let Some(t) = config.trellis {
             enc = enc.with_trellis(t);
         }

--- a/src/expert.rs
+++ b/src/expert.rs
@@ -1,0 +1,45 @@
+//! Expert-only knobs for codec calibration and picker training.
+//!
+//! Anything in this module is **unstable**: it may change in any patch
+//! release without semver justification, and is **not part of the
+//! public API contract**. Reach for it only when:
+//!
+//! 1. Sweeping parameter combinations to feed a picker / regression /
+//!    calibration training pipeline.
+//! 2. Diagnosing codec behaviour by overriding speed-preset defaults.
+//! 3. Wiring a future `predict` feature that selects [`InternalParams`]
+//!    via a baked MLP.
+//!
+//! Everything in here lives behind the `__expert` cargo feature, whose
+//! double-underscore signals "private — do not depend on this in
+//! production code." Default builds expose only stable public knobs
+//! ([`crate::EncoderConfig::with_quality`], `with_speed`, etc.).
+
+/// Expert override knobs for the AVIF encoder.
+///
+/// Each field is `Option<T>`: `None` (the [`Default`]) keeps the speed
+/// preset's value, `Some(_)` overrides it. Apply via
+/// [`crate::EncoderConfig::with_internal_params`].
+///
+/// `#[non_exhaustive]` — fields may be added in any patch release.
+/// Construct via [`Default::default`] and field-by-field assignment.
+#[non_exhaustive]
+#[derive(Default, Clone, Debug)]
+pub struct InternalParams {
+    /// Partition block-size range `(min, max)` in pixels. Each must be
+    /// one of `{4, 8, 16, 32, 64, 128}` and `min <= max`. Smaller mins
+    /// help text/screen content; larger maxes help smooth photo content.
+    pub partition_range: Option<(u8, u8)>,
+
+    /// Override prediction-modes setting. `Some(true)` = ComplexAll
+    /// (slowest). `Some(false)` = Simple (fastest).
+    pub complex_prediction_modes: Option<bool>,
+
+    /// Override loop restoration filter (Wiener / SGR). Helps
+    /// smooth/noisy content; can over-soften line art and text.
+    pub lrf: Option<bool>,
+
+    /// Override fast vs full deblock. `Some(true)` = fast. `Some(false)`
+    /// = full (better edge preservation).
+    pub fast_deblock: Option<bool>,
+}

--- a/src/expert.rs
+++ b/src/expert.rs
@@ -13,7 +13,28 @@
 //! Everything in here lives behind the `__expert` cargo feature, whose
 //! double-underscore signals "private — do not depend on this in
 //! production code." Default builds expose only stable public knobs
-//! ([`crate::EncoderConfig::with_quality`], `with_speed`, etc.).
+//! ([`crate::EncoderConfig::quality`], [`crate::EncoderConfig::speed`],
+//! etc.).
+//!
+//! # Where the overrides land
+//!
+//! [`InternalParams`] is a thin mirror of
+//! [`zenravif::expert::InternalParams`]. Fields fan out one-to-one
+//! through `build_ravif_encoder()` in `src/encoder.rs`, which builds a
+//! `zenravif::expert::InternalParams` and forwards it via
+//! `zenravif::Encoder::with_internal_params`. From there each `Some(_)`
+//! replaces the value the AV1 speed preset would have picked, **after**
+//! `zenrav1e::prelude::SpeedSettings::from_preset` and **after**
+//! zenravif's own preset overrides in `SpeedTweaks::from_my_preset`.
+//! `None` falls through to whatever the preset chose. Apply via
+//! [`crate::EncoderConfig::with_internal_params`]; the call replaces
+//! *all* four fields wholesale, so reset by passing
+//! `InternalParams::default()`.
+//!
+//! For the underlying mechanism, source citations into zenrav1e, and
+//! the speed-preset gating tables, see
+//! [`zenravif::expert::InternalParams`] (which the zenavif wrapper
+//! forwards to verbatim).
 
 /// Expert override knobs for the AVIF encoder.
 ///
@@ -22,24 +43,188 @@
 /// [`crate::EncoderConfig::with_internal_params`].
 ///
 /// `#[non_exhaustive]` — fields may be added in any patch release.
-/// Construct via [`Default::default`] and field-by-field assignment.
+/// Construct via [`Default::default`] and field-by-field assignment;
+/// callers cannot use struct-literal syntax outside this crate.
+///
+/// Forwards to [`zenravif::expert::InternalParams`]; consult that
+/// type's docs for source-line citations into the underlying
+/// zenrav1e encoder.
+///
+/// # Example
+///
+/// ```ignore
+/// # #[cfg(feature = "__expert")] {
+/// use zenavif::{EncoderConfig, expert::InternalParams};
+///
+/// let mut params = InternalParams::default();
+/// params.partition_range = Some((4, 16));
+/// params.lrf = Some(false);
+///
+/// let config = EncoderConfig::new()
+///     .quality(85.0)
+///     .speed(6)
+///     .with_internal_params(params);
+/// # }
+/// ```
 #[non_exhaustive]
 #[derive(Default, Clone, Debug)]
 pub struct InternalParams {
-    /// Partition block-size range `(min, max)` in pixels. Each must be
-    /// one of `{4, 8, 16, 32, 64, 128}` and `min <= max`. Smaller mins
-    /// help text/screen content; larger maxes help smooth photo content.
+    /// Partition block-size search range `(min, max)` in pixels. Each
+    /// bound must be one of `{4, 8, 16, 32, 64}` and `min <= max`.
+    /// (zenrav1e currently rejects `128` via a `max <= 64×64` debug
+    /// assert; passing `128` triggers a debug-mode panic. The wider
+    /// 128 path is reserved for future AV1 large-superblock support.)
+    ///
+    /// **Pipeline stage:** partition / mode decision. Drives the
+    /// recursive AV1 superblock split during RDO. The bounds gate
+    /// `must_split` / `can_split` decisions in zenrav1e's top-down
+    /// and bottom-up partition encoders: `bsize > max` forces a
+    /// split; `bsize > min` allows one. The encoder never tries
+    /// blocks outside the range, so this knob both caps speed and
+    /// constrains the achievable RD curve.
+    ///
+    /// **Why override:**
+    /// - **Sharp text / screen content** benefits from `Some((4, 16))`
+    ///   — small blocks track glyph edges, and large blocks waste bits
+    ///   on transform coefficients that the entropy coder can't reuse.
+    /// - **Smooth photos at q ≥ 85** benefit from `Some((16, 64))` or
+    ///   `Some((32, 64))` — the 4×4/8×8 partitions never win RDO at
+    ///   high q (they pay a partition-flag cost for no distortion
+    ///   improvement) and disabling them shaves encode time.
+    /// - **Calibration sweeps** want `Some((4, 64))` to expose the
+    ///   full RD frontier so a picker can learn where the partition
+    ///   boundaries live (`128` is rejected by zenrav1e — see above).
+    ///
+    /// **Mechanism:** the encoder's RDO loop picks the partition
+    /// shape per superblock by recursing within `[min, max]`. Setting
+    /// both bounds equal (e.g. `Some((16, 16))`) forces fixed-size
+    /// blocks and skips partition RDO entirely. Bounds outside the
+    /// speed preset's range can both expand and contract the search.
+    ///
+    /// **Speed-preset interaction:** zenravif's `SpeedTweaks` clamps
+    /// the upper bound to 16 at high quality and reshapes the range
+    /// per speed; underneath, `SpeedSettings::from_preset` widens to
+    /// `(8, 64)` at speed 3 and shrinks to `(16, 32)` / `(32, 32)` at
+    /// speed 9+. See [`zenravif::expert::InternalParams::partition_range`]
+    /// for exact source citations.
     pub partition_range: Option<(u8, u8)>,
 
-    /// Override prediction-modes setting. `Some(true)` = ComplexAll
-    /// (slowest). `Some(false)` = Simple (fastest).
+    /// Override intra prediction-mode search depth.
+    /// `Some(true)` = `ComplexAll` (all intra modes searched on every
+    /// frame). `Some(false)` = `Simple` (reduced mode set on every
+    /// frame, plus `enable_filter_intra=false` in the AV1 sequence
+    /// header).
+    ///
+    /// **Pipeline stage:** intra prediction / mode decision. Maps to
+    /// zenrav1e's `PredictionModesSetting`, consumed in two RDO
+    /// shortlist sites and at sequence-header build time to decide
+    /// whether `enable_filter_intra` is signalled in the bitstream
+    /// at all.
+    ///
+    /// **Why override:**
+    /// - **Calibration sweeps** that need the full intra search to
+    ///   measure the upper bound of intra-only RD: `Some(true)`.
+    /// - **Diagnosing the still-image guard:** zenravif forces
+    ///   `Simple` for stills because `ComplexAll` triggers
+    ///   `filter_intra` RDO with broken cost estimation that costs
+    ///   ~12 dB PSNR at speed 1 (zenrav1e#5). `Some(true)` lets you
+    ///   reproduce or verify that regression. **Production stills
+    ///   should leave this at `None`** — the override exists to
+    ///   expose the bug, not hide it.
+    /// - **Animated sequences** where the filter-intra bug is less
+    ///   pronounced and the extra modes can recover RD on textured
+    ///   inter frames.
+    ///
+    /// **Mechanism:** `Simple` searches a 3-mode intra shortlist;
+    /// `ComplexKeyframes` (the speed-preset default at speed 0..=6)
+    /// searches a 7-mode list on keyframes only; `ComplexAll`
+    /// searches the 7-mode list on every frame and additionally
+    /// enables filter-intra mode bits in the bitstream. For inter
+    /// RDO, `ComplexAll` switches from a 9-mode shortlist to the
+    /// full inter-mode set.
+    ///
+    /// **Speed-preset interaction:** zenrav1e's preset sets
+    /// `ComplexAll` at speed 0..=1, `ComplexKeyframes` at speed
+    /// 2..=6, and `Simple` at speed 7+. zenravif then **forces
+    /// `Simple` regardless of speed for still images**. Setting this
+    /// to `Some(true)` (=`ComplexAll`) defeats that guard.
     pub complex_prediction_modes: Option<bool>,
 
-    /// Override loop restoration filter (Wiener / SGR). Helps
-    /// smooth/noisy content; can over-soften line art and text.
+    /// Override loop restoration filter (LRF: Wiener + Self-Guided).
+    /// `Some(true)` enables Wiener/SGR search and emits restoration
+    /// units in the bitstream; `Some(false)` disables both and clears
+    /// `enable_restoration` in the AV1 sequence header.
+    ///
+    /// **Pipeline stage:** post-filter (after deblock + CDEF, before
+    /// frame output). LRF runs on the reconstructed frame and stores
+    /// per-restoration-unit filter parameters in the bitstream. The
+    /// flag gates whether Wiener/SGR searches run at all and whether
+    /// restoration unit headers are written.
+    ///
+    /// **Why override:**
+    /// - **Noisy DSLR / film captures at low q (q ≤ 50)**: `Some(true)`
+    ///   recovers measurable PSNR by smoothing reconstruction error
+    ///   that survives deblock+CDEF. The preset already enables LRF
+    ///   here, so the override is for sweeps that need to A/B it.
+    /// - **Smooth photos at q ≥ 85**: `Some(false)` saves encode time
+    ///   with no measurable RD loss — at high q the residual energy
+    ///   LRF would smooth is already below quantization noise.
+    /// - **Line art / pixel art / sharp text**: `Some(false)` prevents
+    ///   LRF from over-softening hard edges that survived deblock.
+    ///
+    /// **Mechanism:** when enabled, the encoder per-frame searches
+    /// Wiener filter coefficients and SGR (self-guided) parameters
+    /// per restoration unit (typically 64×64 or 256×256 pixels). The
+    /// cost is RDO over both filter types plus the rate of
+    /// signalling the chosen coefficients. SGR search depth is
+    /// independently controlled by `sgr_complexity` (not exposed
+    /// here). When disabled, `enable_restoration` in the sequence
+    /// header is `0` and decoders skip the post-filter stage.
+    ///
+    /// **Speed-preset interaction:** zenrav1e enables LRF at speed
+    /// 0..=7 and disables it at speed 8+. zenravif's `SpeedTweaks`
+    /// then narrows that to `low_quality && speed <= 8` — i.e., LRF
+    /// is only on when the quantizer is above ~150 (≈Q50 and below)
+    /// AND speed ≤ 8. At Q ≥ 85 with any speed, the preset turns
+    /// LRF off; this override is the way to flip it back on.
     pub lrf: Option<bool>,
 
-    /// Override fast vs full deblock. `Some(true)` = fast. `Some(false)`
-    /// = full (better edge preservation).
+    /// Override fast vs full deblock-filter level search.
+    /// `Some(true)` = closed-form q-derived deblock level (fast).
+    /// `Some(false)` = full SSE-driven search across deblock levels
+    /// (slow, better edge preservation).
+    ///
+    /// **Pipeline stage:** post-filter (deblock filter level
+    /// optimization, before CDEF). The flag is consumed inside
+    /// zenrav1e's `deblock_filter_optimize`, which decides per
+    /// frame what loop-filter level(s) the reconstruction pass
+    /// will apply.
+    ///
+    /// **Why override:**
+    /// - **Sharp text / screen content / line art**: `Some(false)`
+    ///   keeps the SSE-driven search, which finds smaller deblock
+    ///   levels and preserves the hard edges the closed-form formula
+    ///   would over-smooth.
+    /// - **Smooth photos / video where speed matters**: `Some(true)`
+    ///   skips the per-frame search and uses a precomputed level. The
+    ///   formula was fit on natural images; it produces the right
+    ///   answer there but can over-blur or under-blur on outliers.
+    /// - **Diagnosing edge artifacts**: flipping the flag is the
+    ///   fastest way to confirm whether deblock-level search is the
+    ///   cause.
+    ///
+    /// **Mechanism:** when fast, the level is computed in closed form
+    /// from the AC quantizer and frame type via 8/10/12-bpc-specific
+    /// fixed-point coefficients. When slow, `sse_optimize` searches
+    /// deblock levels by reconstructing each 4×4 luma block and
+    /// minimizing reconstruction SSE against the source. The slow
+    /// path can run dozens of trial reconstructions per frame.
+    ///
+    /// **Speed-preset interaction:** zenrav1e enables `fast_deblock`
+    /// at speed 7+. zenravif's `SpeedTweaks` further restricts that
+    /// to `speed >= 7 && !high_quality` — i.e., at Q ≥ 80 the slow
+    /// search runs even at speed 10. Override `Some(true)` if you
+    /// want the fast path at high q, or `Some(false)` to force the
+    /// slow search at any speed for edge-sensitive content.
     pub fast_deblock: Option<bool>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@ pub mod detect;
 #[cfg(feature = "encode")]
 mod encoder;
 mod error;
+#[cfg(feature = "__expert")]
+pub mod expert;
 mod image;
 #[cfg(feature = "_dev")]
 pub mod simd;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub mod simd;
 #[cfg(not(feature = "_dev"))]
 pub(crate) mod simd;
 mod strip_convert;
+mod validation;
 #[cfg(feature = "_dev")]
 pub mod yuv_convert;
 #[cfg(not(feature = "_dev"))]
@@ -132,6 +133,7 @@ pub use image::{
     GainMapMetadata, ImageInfo, ImageMirror, ImageRotation, MasteringDisplayColourVolume,
     MatrixCoefficients, PixelAspectRatio, TransferCharacteristics,
 };
+pub use validation::ValidationError;
 pub use zenpixels::PixelBuffer;
 
 /// Decode an AVIF image with default settings

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,0 +1,352 @@
+//! Configuration validation.
+//!
+//! Provides [`ValidationError`] plus `validate()` methods on every
+//! public `Config` type. Existing encode/decode entry points keep
+//! their clamping behaviour — `validate()` is a fail-fast option
+//! callers can opt into for batch jobs that want hard rejection on
+//! out-of-range values rather than silent clamping.
+//!
+//! ```no_run
+//! # #[cfg(feature = "encode")] {
+//! use zenavif::EncoderConfig;
+//!
+//! let cfg = EncoderConfig::new().quality(150.0);
+//! assert!(cfg.validate().is_err()); // out of 0.0..=100.0
+//! # }
+//! ```
+//!
+//! Validation never mutates the config and never reports a "fixed"
+//! value — it reports the issue and lets the caller decide.
+
+use core::ops::RangeInclusive;
+
+/// Reasons a [`crate::EncoderConfig`], [`crate::DecoderConfig`], or
+/// [`crate::expert::InternalParams`] fails validation.
+///
+/// `#[non_exhaustive]` — variants may be added in any patch release as
+/// new configuration knobs are introduced.
+#[non_exhaustive]
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ValidationError {
+    // --- EncoderConfig ---
+    /// Encoder `quality` must be within `0.0..=100.0`.
+    #[error("encoder quality {value} out of valid range {valid:?}")]
+    QualityOutOfRange {
+        /// The offending value.
+        value: f32,
+        /// The valid range.
+        valid: RangeInclusive<f32>,
+    },
+
+    /// Encoder `alpha_quality` must be within `0.0..=100.0`.
+    #[error("encoder alpha_quality {value} out of valid range {valid:?}")]
+    AlphaQualityOutOfRange {
+        /// The offending value.
+        value: f32,
+        /// The valid range.
+        valid: RangeInclusive<f32>,
+    },
+
+    /// Encoder `speed` must be within `1..=10`.
+    #[error("encoder speed {value} out of valid range {valid:?}")]
+    SpeedOutOfRange {
+        /// The offending value.
+        value: u8,
+        /// The valid range.
+        valid: RangeInclusive<u8>,
+    },
+
+    /// Encoder `threads`, when `Some`, must be greater than zero.
+    /// Use `None` for the rayon default.
+    #[error("encoder threads must be > 0 when Some(_); got Some(0)")]
+    EncoderThreadsZero,
+
+    /// Encoder `rotation` must be one of `0`, `90`, `180`, `270`.
+    #[error("encoder rotation {value} invalid: must be one of {{0, 90, 180, 270}}")]
+    RotationInvalid {
+        /// The offending value.
+        value: u8,
+    },
+
+    /// Encoder `mirror` axis must be `0` (vertical) or `1` (horizontal).
+    #[error("encoder mirror {value} invalid: must be 0 (vertical) or 1 (horizontal)")]
+    MirrorInvalid {
+        /// The offending value.
+        value: u8,
+    },
+
+    /// CICP code-point fields (color_primaries, transfer_characteristics,
+    /// matrix_coefficients) must fit ITU-T H.273. The validator rejects
+    /// the reserved value `3`.
+    #[error("CICP {field} value {value} is reserved (3 is reserved per ITU-T H.273)")]
+    CicpReserved {
+        /// Which CICP field.
+        field: &'static str,
+        /// The offending value.
+        value: u8,
+    },
+
+    /// VAQ strength must be within `0.0..=4.0`.
+    #[error("VAQ strength {value} out of valid range {valid:?}")]
+    VaqStrengthOutOfRange {
+        /// The offending value.
+        value: f64,
+        /// The valid range.
+        valid: RangeInclusive<f64>,
+    },
+
+    /// Segmentation boost out of valid range. zenravif accepts
+    /// `0.5..=4.0`; `1.0` is "off" and `>1.0` widens deltas. Values
+    /// `<0.5` or `>4.0` are rejected.
+    #[error("seg_boost {value} out of valid range {valid:?}")]
+    SegBoostOutOfRange {
+        /// The offending value.
+        value: f64,
+        /// The valid range.
+        valid: RangeInclusive<f64>,
+    },
+
+    /// Two parameters that cannot both be set / both be true.
+    #[error("mutually exclusive: {a} and {b} cannot both be set")]
+    MutuallyExclusive {
+        /// First parameter name.
+        a: &'static str,
+        /// Second parameter name.
+        b: &'static str,
+    },
+
+    // --- DecoderConfig ---
+    /// Decoder `frame_size_limit` cannot use a sentinel reserved by
+    /// the validator. The current decoder treats `0` as "no limit"
+    /// at runtime, but for validation purposes a non-zero positive
+    /// limit must be supplied if the caller wants a bound. Use
+    /// `frame_size_limit(0)` plus skipping `validate()` to opt out.
+    /// Reserved for future use; not currently emitted.
+    #[error("decoder frame size limit {value} cannot be zero")]
+    DecoderFrameSizeLimitZero {
+        /// The offending value.
+        value: u64,
+    },
+
+    // --- expert::InternalParams ---
+    /// `partition_range` must satisfy `min <= max` and both bounds
+    /// must be in `{4, 8, 16, 32, 64}`. zenrav1e debug-asserts on
+    /// `128`, so it is rejected here.
+    #[error(
+        "partition_range {min}..{max} invalid: \
+         must satisfy min <= max and both ∈ {{4, 8, 16, 32, 64}}"
+    )]
+    PartitionRangeInvalid {
+        /// The offending lower bound.
+        min: u8,
+        /// The offending upper bound.
+        max: u8,
+    },
+}
+
+/// Returns true if `v` is a valid AV1 partition block-size bound.
+/// zenrav1e accepts `{4, 8, 16, 32, 64}`; `128` is reserved for
+/// future large-superblock support and triggers a debug-assert today.
+#[cfg(feature = "__expert")]
+fn partition_bound_ok(v: u8) -> bool {
+    matches!(v, 4 | 8 | 16 | 32 | 64)
+}
+
+#[cfg(feature = "__expert")]
+impl crate::expert::InternalParams {
+    /// Validate this `InternalParams` value.
+    ///
+    /// Returns `Err` if any `Some(_)` field is outside its accepted
+    /// range. The most relevant invariant is `partition_range`: both
+    /// bounds must be in `{4, 8, 16, 32, 64}` and `min <= max`. The
+    /// `128` superblock size is reserved for future AV1 large-superblock
+    /// support and triggers a zenrav1e debug-assert today.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if let Some((min, max)) = self.partition_range
+            && (!partition_bound_ok(min) || !partition_bound_ok(max) || min > max)
+        {
+            return Err(ValidationError::PartitionRangeInvalid { min, max });
+        }
+        // complex_prediction_modes / lrf / fast_deblock are bool
+        // overrides — every value of `Option<bool>` is well-formed.
+        Ok(())
+    }
+}
+
+#[cfg(feature = "encode")]
+impl crate::EncoderConfig {
+    /// Validate this `EncoderConfig` value.
+    ///
+    /// Returns `Err` on the first failed invariant. Validation does
+    /// not mutate the config; existing encode entry points still
+    /// clamp out-of-range values silently. Use this method when you
+    /// want hard rejection (batch jobs, calibration sweeps, public
+    /// HTTP endpoints) instead of silent clamping.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        let q_range: RangeInclusive<f32> = 0.0..=100.0;
+
+        // quality
+        if !q_range.contains(&self.quality) || !self.quality.is_finite() {
+            return Err(ValidationError::QualityOutOfRange {
+                value: self.quality,
+                valid: q_range.clone(),
+            });
+        }
+
+        // alpha_quality
+        if let Some(aq) = self.alpha_quality
+            && (!q_range.contains(&aq) || !aq.is_finite())
+        {
+            return Err(ValidationError::AlphaQualityOutOfRange {
+                value: aq,
+                valid: q_range.clone(),
+            });
+        }
+
+        // speed: 1..=10. zenravif documents "1 = slowest/best, 10 = fastest/worst"
+        // and SpeedSettings::from_preset clamps; we reject 0 and >10.
+        let speed_range: RangeInclusive<u8> = 1..=10;
+        if !speed_range.contains(&self.speed) {
+            return Err(ValidationError::SpeedOutOfRange {
+                value: self.speed,
+                valid: speed_range,
+            });
+        }
+
+        // threads: Option<usize>. None = rayon default, Some(0) is meaningless.
+        if let Some(0) = self.threads {
+            return Err(ValidationError::EncoderThreadsZero);
+        }
+
+        // rotation: AVIF irot box stores the angle as a 2-bit
+        // quarter-turn code (0=0°, 1=90°, 2=180°, 3=270°). The
+        // serializer masks the input to `& 0x03`, so passing
+        // degrees (90, 180, 270) silently maps to wrong rotations.
+        // We require the irot code-point form {0, 1, 2, 3} for
+        // forwarding parity with zenravif's validator, which uses
+        // `ROTATION_RANGE = 0..=3`.
+        if let Some(angle) = self.rotation
+            && angle > 3
+        {
+            return Err(ValidationError::RotationInvalid { value: angle });
+        }
+
+        // mirror axis: AVIF imir spec — 0 = vertical, 1 = horizontal.
+        if let Some(axis) = self.mirror
+            && axis > 1
+        {
+            return Err(ValidationError::MirrorInvalid { value: axis });
+        }
+
+        // CICP code points (ITU-T H.273): 3 is reserved across all three fields.
+        if let Some(cp) = self.color_primaries
+            && cp == 3
+        {
+            return Err(ValidationError::CicpReserved {
+                field: "color_primaries",
+                value: cp,
+            });
+        }
+        if let Some(tc) = self.transfer_characteristics
+            && tc == 3
+        {
+            return Err(ValidationError::CicpReserved {
+                field: "transfer_characteristics",
+                value: tc,
+            });
+        }
+        if let Some(mc) = self.matrix_coefficients
+            && mc == 3
+        {
+            return Err(ValidationError::CicpReserved {
+                field: "matrix_coefficients",
+                value: mc,
+            });
+        }
+
+        // encode-imazen knobs.
+        #[cfg(feature = "encode-imazen")]
+        {
+            // VAQ strength range matches zenravif/zenrav1e's accepted
+            // band: 0.0 (off) through 4.0 (aggressive).
+            let vaq_range: RangeInclusive<f64> = 0.0..=4.0;
+            if !vaq_range.contains(&self.vaq_strength) || !self.vaq_strength.is_finite() {
+                return Err(ValidationError::VaqStrengthOutOfRange {
+                    value: self.vaq_strength,
+                    valid: vaq_range,
+                });
+            }
+
+            // seg_boost: zenravif's SEG_BOOST_RANGE = 0.5..=4.0.
+            let seg_range: RangeInclusive<f64> = 0.5..=4.0;
+            if let Some(b) = self.seg_boost
+                && (!b.is_finite() || !seg_range.contains(&b))
+            {
+                return Err(ValidationError::SegBoostOutOfRange {
+                    value: b,
+                    valid: seg_range,
+                });
+            }
+
+            // Cross-param: lossless overrides quality and is incompatible
+            // with VAQ enabled (zenravif disables QM internally for lossless;
+            // VAQ on top of quantizer=0 has no defined meaning).
+            if self.lossless && self.enable_vaq {
+                return Err(ValidationError::MutuallyExclusive {
+                    a: "lossless",
+                    b: "vaq",
+                });
+            }
+
+            // Cross-param: lossless + tune_still_image — still-image tuning
+            // changes deblock/CDEF tradeoffs that have no effect at q=0
+            // but the combination is conceptually nonsensical and the
+            // zenrav1e benchmark notes call out tune_still_image as a no-op
+            // at high q. We allow it; only the quantizer=0 vs VAQ pair is
+            // rejected because VAQ actively conflicts with the quantizer.
+        }
+
+        // expert::InternalParams forwarded fields. We re-validate the
+        // partition_range bounds at the EncoderConfig level so callers
+        // who set the field via `with_internal_params` get a single
+        // call site for validation.
+        #[cfg(feature = "__expert")]
+        {
+            if let Some((min, max)) = self.override_partition_range
+                && (!partition_bound_ok(min) || !partition_bound_ok(max) || min > max)
+            {
+                return Err(ValidationError::PartitionRangeInvalid { min, max });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl crate::DecoderConfig {
+    /// Validate this `DecoderConfig` value.
+    ///
+    /// Returns `Err` on the first failed invariant. The decoder
+    /// itself accepts `frame_size_limit = 0` as "no limit"; this
+    /// method does **not** reject zero (no caller should be forced
+    /// to pick an arbitrary cap). It validates positively-set
+    /// numeric fields where a wrong value would silently misconfigure
+    /// the decoder.
+    ///
+    /// `threads = 0` is the documented "auto-detect" sentinel and is
+    /// accepted; positive values are also accepted. There is no
+    /// invalid threads value at the moment.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        // Currently no DecoderConfig field has an invalid range:
+        //   - threads: 0 = auto, any u32 accepted.
+        //   - apply_grain: bool, every value valid.
+        //   - frame_size_limit: 0 = no limit, any u32 accepted.
+        //   - cpu_flags_mask: any u32 valid (0 = scalar-only).
+        //   - parser_*_limit: Option<_>, every value valid.
+        //   - prefer_8bit: bool, every value valid.
+        //
+        // The variant `DecoderFrameSizeLimitZero` is reserved for
+        // future use if a stricter mode is added.
+        Ok(())
+    }
+}

--- a/tests/expert_internal_params.rs
+++ b/tests/expert_internal_params.rs
@@ -1,0 +1,331 @@
+//! Permutation, idempotency, and forwarding-parity coverage for the
+//! `__expert` feature's `InternalParams` knobs.
+//!
+//! Each non-default field must produce a different bitstream than
+//! baseline; applying the same `InternalParams` twice must be
+//! idempotent; setting all four fields must produce a valid encode;
+//! `Default` must be byte-identical to no override; resetting via
+//! `Default` must restore baseline; and zenavif's wrapper must
+//! produce the same bytes as zenravif's `Encoder::with_internal_params`
+//! directly.
+
+#![cfg(feature = "__expert")]
+
+use almost_enough::{StopToken, Unstoppable};
+use imgref::{Img, ImgRef};
+use rgb::Rgb;
+use zenavif::{EncoderConfig, encode_rgb8, expert::InternalParams};
+
+const W: u32 = 96;
+const H: u32 = 96;
+
+fn stop() -> StopToken {
+    StopToken::new(Unstoppable)
+}
+
+/// 96×96 synthetic RGB image: gradient + xor pattern.
+///
+/// The xor texture has frequencies that exercise both small partitions
+/// (high-frequency speckle) and larger ones (smooth gradient).
+fn make_image() -> Img<Vec<Rgb<u8>>> {
+    let w = W as usize;
+    let h = H as usize;
+    let mut pixels = Vec::with_capacity(w * h);
+    for y in 0..h {
+        for x in 0..w {
+            let xor = ((x ^ y) & 0xff) as u8;
+            let gx = ((x * 255) / (w - 1)) as u8;
+            let gy = ((y * 255) / (h - 1)) as u8;
+            pixels.push(Rgb {
+                r: gx.wrapping_add(xor),
+                g: gy.wrapping_add(xor.rotate_left(3)),
+                b: xor.wrapping_add(gx.wrapping_mul(2)),
+            });
+        }
+    }
+    Img::new(pixels, w, h)
+}
+
+fn baseline_config() -> EncoderConfig {
+    EncoderConfig::new().quality(60.0).speed(6).threads(Some(1))
+}
+
+fn encode_with_params(img: ImgRef<'_, Rgb<u8>>, params: InternalParams) -> Vec<u8> {
+    let cfg = baseline_config().with_internal_params(params);
+    encode_rgb8(img, &cfg, stop())
+        .expect("encode should succeed")
+        .avif_file
+}
+
+fn baseline_bytes(img: ImgRef<'_, Rgb<u8>>) -> Vec<u8> {
+    let cfg = baseline_config();
+    encode_rgb8(img, &cfg, stop())
+        .expect("encode should succeed")
+        .avif_file
+}
+
+// ---------------------------------------------------------------------------
+// (a) Per-field tests: each field set to non-None changes the bitstream.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn partition_range_4_16_differs_from_baseline() {
+    let img = make_image();
+    let baseline = baseline_bytes(img.as_ref());
+    let mut p = InternalParams::default();
+    p.partition_range = Some((4, 16));
+    let overridden = encode_with_params(img.as_ref(), p);
+    assert_ne!(
+        baseline, overridden,
+        "partition_range Some((4, 16)) must change the bitstream"
+    );
+}
+
+#[test]
+fn partition_range_16_64_differs_from_baseline() {
+    let img = make_image();
+    let baseline = baseline_bytes(img.as_ref());
+    let mut p = InternalParams::default();
+    p.partition_range = Some((16, 64));
+    let overridden = encode_with_params(img.as_ref(), p);
+    assert_ne!(
+        baseline, overridden,
+        "partition_range Some((16, 64)) must change the bitstream"
+    );
+}
+
+#[test]
+fn partition_range_4_64_produces_valid_encode() {
+    // Full range — exercises the upper-bound zenrav1e clamp at 64.
+    // (128 is rejected by zenrav1e debug-asserts, so the maximum
+    // valid value is 64.)
+    let img = make_image();
+    let mut p = InternalParams::default();
+    p.partition_range = Some((4, 64));
+    let bytes = encode_with_params(img.as_ref(), p);
+    assert!(!bytes.is_empty());
+    let decoded = zenavif::decode(&bytes).expect("decode should succeed");
+    assert_eq!(decoded.width(), W);
+    assert_eq!(decoded.height(), H);
+}
+
+#[test]
+fn complex_prediction_modes_true_differs_from_false() {
+    let img = make_image();
+    let mut p_on = InternalParams::default();
+    p_on.complex_prediction_modes = Some(true);
+    let mut p_off = InternalParams::default();
+    p_off.complex_prediction_modes = Some(false);
+    let on = encode_with_params(img.as_ref(), p_on);
+    let off = encode_with_params(img.as_ref(), p_off);
+    assert_ne!(
+        on, off,
+        "complex_prediction_modes Some(true) vs Some(false) must differ"
+    );
+}
+
+#[test]
+fn lrf_true_differs_from_false() {
+    let img = make_image();
+    let mut p_on = InternalParams::default();
+    p_on.lrf = Some(true);
+    let mut p_off = InternalParams::default();
+    p_off.lrf = Some(false);
+    let on = encode_with_params(img.as_ref(), p_on);
+    let off = encode_with_params(img.as_ref(), p_off);
+    assert_ne!(on, off, "lrf Some(true) vs Some(false) must differ");
+}
+
+#[test]
+fn fast_deblock_true_differs_from_false() {
+    let img = make_image();
+    let mut p_fast = InternalParams::default();
+    p_fast.fast_deblock = Some(true);
+    let mut p_full = InternalParams::default();
+    p_full.fast_deblock = Some(false);
+    let fast = encode_with_params(img.as_ref(), p_fast);
+    let full = encode_with_params(img.as_ref(), p_full);
+    assert_ne!(
+        fast, full,
+        "fast_deblock Some(true) vs Some(false) must differ"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) Idempotency: applying the same InternalParams twice == once.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn idempotency_partition_range() {
+    let img = make_image();
+    let mut p = InternalParams::default();
+    p.partition_range = Some((4, 16));
+
+    let once = encode_with_params(img.as_ref(), p.clone());
+
+    // Apply twice through the builder.
+    let cfg = baseline_config()
+        .with_internal_params(p.clone())
+        .with_internal_params(p);
+    let twice = encode_rgb8(img.as_ref(), &cfg, stop())
+        .expect("encode should succeed")
+        .avif_file;
+
+    assert_eq!(
+        once, twice,
+        "applying same InternalParams twice must equal applying it once"
+    );
+}
+
+#[test]
+fn idempotency_all_fields() {
+    let img = make_image();
+    let mut p = InternalParams::default();
+    p.partition_range = Some((4, 64));
+    p.complex_prediction_modes = Some(true);
+    p.lrf = Some(true);
+    p.fast_deblock = Some(false);
+
+    let once = encode_with_params(img.as_ref(), p.clone());
+
+    let cfg = baseline_config()
+        .with_internal_params(p.clone())
+        .with_internal_params(p);
+    let twice = encode_rgb8(img.as_ref(), &cfg, stop())
+        .expect("encode should succeed")
+        .avif_file;
+
+    assert_eq!(once, twice);
+}
+
+// ---------------------------------------------------------------------------
+// (c) Combined: all four fields set produces a valid encode.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn combined_all_fields_set_produces_valid_encode() {
+    let img = make_image();
+    let mut p = InternalParams::default();
+    p.partition_range = Some((4, 64));
+    p.complex_prediction_modes = Some(true);
+    p.lrf = Some(true);
+    p.fast_deblock = Some(false);
+
+    let bytes = encode_with_params(img.as_ref(), p);
+    assert!(
+        !bytes.is_empty(),
+        "combined override must produce > 0 bytes"
+    );
+
+    let decoded = zenavif::decode(&bytes).expect("decode should succeed");
+    assert_eq!(decoded.width(), W);
+    assert_eq!(decoded.height(), H);
+}
+
+// ---------------------------------------------------------------------------
+// (d) Default = baseline: bit-exact same bytes as no override.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_internal_params_is_byte_identical_to_baseline() {
+    let img = make_image();
+    let baseline = baseline_bytes(img.as_ref());
+    let with_default = encode_with_params(img.as_ref(), InternalParams::default());
+    assert_eq!(
+        baseline, with_default,
+        "InternalParams::default() must be bit-identical to no override"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (e) Reset: setting one field, then re-applying Default, restores baseline.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reset_via_default_restores_baseline() {
+    let img = make_image();
+    let baseline = baseline_bytes(img.as_ref());
+
+    let mut p = InternalParams::default();
+    p.partition_range = Some((4, 16));
+    p.lrf = Some(true);
+
+    // Apply override, then reset by re-applying a fresh Default.
+    let cfg = baseline_config()
+        .with_internal_params(p)
+        .with_internal_params(InternalParams::default());
+    let after_reset = encode_rgb8(img.as_ref(), &cfg, stop())
+        .expect("encode should succeed")
+        .avif_file;
+
+    assert_eq!(
+        baseline, after_reset,
+        "re-applying Default must reset all fields to baseline"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (f) Forwarding parity: zenavif's wrapper produces the same bytes as
+//     ravif's `Encoder::with_internal_params` directly.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn forwarding_parity_with_ravif_direct() {
+    use ravif::Encoder as RavifEncoder;
+
+    let img = make_image();
+
+    // Build params on both sides with the same field values.
+    let mut zen_params = InternalParams::default();
+    zen_params.partition_range = Some((4, 64));
+    zen_params.complex_prediction_modes = Some(true);
+    zen_params.lrf = Some(false);
+    zen_params.fast_deblock = Some(true);
+
+    let mut ravif_params = ravif::expert::InternalParams::default();
+    ravif_params.partition_range = Some((4, 64));
+    ravif_params.complex_prediction_modes = Some(true);
+    ravif_params.lrf = Some(false);
+    ravif_params.fast_deblock = Some(true);
+
+    // Encode via zenavif's wrapper at quality=60 / speed=6 / 1 thread,
+    // QM enabled (zenavif default), VAQ off, still-image off, lossless off.
+    let zen_cfg = baseline_config().with_internal_params(zen_params);
+    let zen_bytes = encode_rgb8(img.as_ref(), &zen_cfg, stop())
+        .expect("zenavif encode should succeed")
+        .avif_file;
+
+    // Build the equivalent ravif encoder directly with the same knobs
+    // that build_ravif_encoder() applies under encode-imazen + __expert.
+    // Defaults match EncoderConfig::default(): qm=true, vaq=false,
+    // tune_still=false, lossless=false; bit_depth=8 (auto on 8-bit input).
+    let ravif_enc = RavifEncoder::new()
+        .with_quality(60.0)
+        .with_speed(6)
+        .with_bit_depth(ravif::BitDepth::Eight)
+        .with_internal_color_model(ravif::ColorModel::YCbCr)
+        .with_alpha_color_mode(ravif::AlphaColorMode::UnassociatedClean)
+        .with_num_threads(Some(1))
+        .with_qm(true)
+        .with_vaq(false, 1.0)
+        .with_still_image_tuning(false)
+        .with_lossless(false)
+        .with_cdef(None)
+        .with_rdo_tx_decision(None)
+        .with_sgr_full(None)
+        .with_lru_on_skip(None)
+        .with_segmentation_complex(None)
+        .with_encode_bottomup(None)
+        .with_internal_params(ravif_params)
+        .with_stop(stop());
+
+    let ravif_bytes = ravif_enc
+        .encode_rgb(img.as_ref())
+        .expect("ravif direct encode should succeed")
+        .avif_file;
+
+    assert_eq!(
+        zen_bytes, ravif_bytes,
+        "zenavif wrapper must forward InternalParams faithfully to ravif"
+    );
+}

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -1,0 +1,395 @@
+//! Per-error-variant + happy-path coverage for `Config::validate()`.
+//!
+//! Each `ValidationError` variant gets one synthetic config that
+//! triggers it; default-constructed configs must always validate.
+
+use zenavif::{DecoderConfig, ValidationError};
+
+#[cfg(feature = "encode")]
+use zenavif::EncoderConfig;
+
+// --------------------------------------------------------------------
+// Happy paths
+// --------------------------------------------------------------------
+
+#[test]
+fn decoder_default_validates() {
+    DecoderConfig::default()
+        .validate()
+        .expect("default DecoderConfig must validate");
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn encoder_default_validates() {
+    EncoderConfig::default()
+        .validate()
+        .expect("default EncoderConfig must validate");
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn encoder_typical_config_validates() {
+    let cfg = EncoderConfig::new()
+        .quality(85.0)
+        .speed(6)
+        .alpha_quality(80.0)
+        .threads(Some(4))
+        .rotation(2)
+        .mirror(0);
+    cfg.validate().expect("typical config must validate");
+}
+
+#[cfg(feature = "__expert")]
+#[test]
+fn expert_default_internal_params_validates() {
+    use zenavif::expert::InternalParams;
+    InternalParams::default()
+        .validate()
+        .expect("default InternalParams must validate");
+}
+
+#[cfg(feature = "__expert")]
+#[test]
+fn expert_internal_params_well_formed_validates() {
+    use zenavif::expert::InternalParams;
+    let mut p = InternalParams::default();
+    p.partition_range = Some((8, 32));
+    p.lrf = Some(true);
+    p.fast_deblock = Some(false);
+    p.complex_prediction_modes = Some(true);
+    p.validate()
+        .expect("well-formed InternalParams must validate");
+}
+
+// --------------------------------------------------------------------
+// EncoderConfig: per-variant
+// --------------------------------------------------------------------
+
+#[cfg(feature = "encode")]
+#[test]
+fn quality_out_of_range_high() {
+    let cfg = EncoderConfig::new().quality(150.0);
+    match cfg.validate() {
+        Err(ValidationError::QualityOutOfRange { value, valid }) => {
+            assert_eq!(value, 150.0);
+            assert_eq!(*valid.start(), 0.0);
+            assert_eq!(*valid.end(), 100.0);
+        }
+        other => panic!("expected QualityOutOfRange, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn quality_out_of_range_negative() {
+    let cfg = EncoderConfig::new().quality(-1.0);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::QualityOutOfRange { .. })
+    ));
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn quality_nan() {
+    let cfg = EncoderConfig::new().quality(f32::NAN);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::QualityOutOfRange { .. })
+    ));
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn alpha_quality_out_of_range() {
+    let cfg = EncoderConfig::new().alpha_quality(101.0);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::AlphaQualityOutOfRange { .. })
+    ));
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn speed_out_of_range_zero() {
+    let cfg = EncoderConfig::new().speed(0);
+    match cfg.validate() {
+        Err(ValidationError::SpeedOutOfRange { value, valid }) => {
+            assert_eq!(value, 0);
+            assert_eq!(*valid.start(), 1);
+            assert_eq!(*valid.end(), 10);
+        }
+        other => panic!("expected SpeedOutOfRange, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn speed_out_of_range_high() {
+    let cfg = EncoderConfig::new().speed(11);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::SpeedOutOfRange { .. })
+    ));
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn encoder_threads_zero() {
+    let cfg = EncoderConfig::new().threads(Some(0));
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::EncoderThreadsZero)
+    ));
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn encoder_threads_none_ok() {
+    let cfg = EncoderConfig::new().threads(None);
+    cfg.validate().expect("threads=None must validate");
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn rotation_invalid() {
+    // Anything > 3 is invalid (irot box stores 2-bit code).
+    let cfg = EncoderConfig::new().rotation(90);
+    match cfg.validate() {
+        Err(ValidationError::RotationInvalid { value }) => assert_eq!(value, 90),
+        other => panic!("expected RotationInvalid, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn rotation_quarter_turn_codes_ok() {
+    for code in 0u8..=3 {
+        let cfg = EncoderConfig::new().rotation(code);
+        cfg.validate()
+            .unwrap_or_else(|e| panic!("rotation={code} must validate, got {e:?}"));
+    }
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn mirror_invalid() {
+    let cfg = EncoderConfig::new().mirror(2);
+    match cfg.validate() {
+        Err(ValidationError::MirrorInvalid { value }) => assert_eq!(value, 2),
+        other => panic!("expected MirrorInvalid, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn cicp_color_primaries_reserved() {
+    let cfg = EncoderConfig::new().color_primaries(3);
+    match cfg.validate() {
+        Err(ValidationError::CicpReserved { field, value }) => {
+            assert_eq!(field, "color_primaries");
+            assert_eq!(value, 3);
+        }
+        other => panic!("expected CicpReserved, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn cicp_transfer_characteristics_reserved() {
+    let cfg = EncoderConfig::new().transfer_characteristics(3);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::CicpReserved {
+            field: "transfer_characteristics",
+            ..
+        })
+    ));
+}
+
+#[cfg(feature = "encode")]
+#[test]
+fn cicp_matrix_coefficients_reserved() {
+    let cfg = EncoderConfig::new().matrix_coefficients(3);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::CicpReserved {
+            field: "matrix_coefficients",
+            ..
+        })
+    ));
+}
+
+// --------------------------------------------------------------------
+// encode-imazen variants
+// --------------------------------------------------------------------
+
+#[cfg(feature = "encode-imazen")]
+#[test]
+fn vaq_strength_out_of_range_high() {
+    let cfg = EncoderConfig::new().with_vaq(true, 5.0);
+    match cfg.validate() {
+        Err(ValidationError::VaqStrengthOutOfRange { value, valid }) => {
+            assert_eq!(value, 5.0);
+            assert_eq!(*valid.start(), 0.0);
+            assert_eq!(*valid.end(), 4.0);
+        }
+        other => panic!("expected VaqStrengthOutOfRange, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "encode-imazen")]
+#[test]
+fn vaq_strength_out_of_range_negative() {
+    let cfg = EncoderConfig::new().with_vaq(true, -0.1);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::VaqStrengthOutOfRange { .. })
+    ));
+}
+
+#[cfg(feature = "encode-imazen")]
+#[test]
+fn seg_boost_below_half() {
+    let cfg = EncoderConfig::new().with_seg_boost(Some(0.4));
+    match cfg.validate() {
+        Err(ValidationError::SegBoostOutOfRange { value, valid }) => {
+            assert_eq!(value, 0.4);
+            assert_eq!(*valid.start(), 0.5);
+            assert_eq!(*valid.end(), 4.0);
+        }
+        other => panic!("expected SegBoostOutOfRange, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "encode-imazen")]
+#[test]
+fn seg_boost_above_four() {
+    let cfg = EncoderConfig::new().with_seg_boost(Some(4.5));
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::SegBoostOutOfRange { .. })
+    ));
+}
+
+#[cfg(feature = "encode-imazen")]
+#[test]
+fn seg_boost_one_ok() {
+    let cfg = EncoderConfig::new().with_seg_boost(Some(1.0));
+    cfg.validate().expect("seg_boost=1.0 (off) must validate");
+}
+
+#[cfg(feature = "encode-imazen")]
+#[test]
+fn lossless_and_vaq_mutually_exclusive() {
+    let cfg = EncoderConfig::new().with_lossless(true).with_vaq(true, 1.0);
+    match cfg.validate() {
+        Err(ValidationError::MutuallyExclusive { a, b }) => {
+            assert_eq!(a, "lossless");
+            assert_eq!(b, "vaq");
+        }
+        other => panic!("expected MutuallyExclusive, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "encode-imazen")]
+#[test]
+fn lossless_alone_ok() {
+    let cfg = EncoderConfig::new().with_lossless(true);
+    cfg.validate().expect("lossless alone must validate");
+}
+
+// --------------------------------------------------------------------
+// expert::InternalParams: per-variant
+// --------------------------------------------------------------------
+
+#[cfg(feature = "__expert")]
+#[test]
+fn partition_range_min_gt_max() {
+    use zenavif::expert::InternalParams;
+    let mut p = InternalParams::default();
+    p.partition_range = Some((32, 8));
+    match p.validate() {
+        Err(ValidationError::PartitionRangeInvalid { min, max }) => {
+            assert_eq!(min, 32);
+            assert_eq!(max, 8);
+        }
+        other => panic!("expected PartitionRangeInvalid, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "__expert")]
+#[test]
+fn partition_range_invalid_size() {
+    use zenavif::expert::InternalParams;
+    let mut p = InternalParams::default();
+    p.partition_range = Some((4, 7)); // 7 not in {4,8,16,32,64}
+    assert!(matches!(
+        p.validate(),
+        Err(ValidationError::PartitionRangeInvalid { .. })
+    ));
+}
+
+#[cfg(feature = "__expert")]
+#[test]
+fn partition_range_128_rejected() {
+    use zenavif::expert::InternalParams;
+    let mut p = InternalParams::default();
+    p.partition_range = Some((4, 128)); // zenrav1e debug-asserts on 128
+    match p.validate() {
+        Err(ValidationError::PartitionRangeInvalid { min, max }) => {
+            assert_eq!(min, 4);
+            assert_eq!(max, 128);
+        }
+        other => panic!("expected PartitionRangeInvalid for 128, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "__expert")]
+#[test]
+fn partition_range_valid_combinations() {
+    use zenavif::expert::InternalParams;
+    let valid_pairs: &[(u8, u8)] = &[(4, 4), (4, 64), (8, 16), (16, 32), (32, 64), (64, 64)];
+    for &(min, max) in valid_pairs {
+        let mut p = InternalParams::default();
+        p.partition_range = Some((min, max));
+        p.validate()
+            .unwrap_or_else(|e| panic!("({min},{max}) must validate, got {e:?}"));
+    }
+}
+
+#[cfg(feature = "__expert")]
+#[test]
+fn encoder_config_forwards_partition_validation() {
+    use zenavif::expert::InternalParams;
+    let mut p = InternalParams::default();
+    p.partition_range = Some((128, 128));
+    let cfg = EncoderConfig::new().with_internal_params(p);
+    assert!(matches!(
+        cfg.validate(),
+        Err(ValidationError::PartitionRangeInvalid { .. })
+    ));
+}
+
+// --------------------------------------------------------------------
+// DecoderConfig: currently no failing variants. Reserved.
+// --------------------------------------------------------------------
+
+#[test]
+fn decoder_threads_zero_ok() {
+    // 0 is the documented "auto-detect" sentinel.
+    DecoderConfig::new()
+        .threads(0)
+        .validate()
+        .expect("threads=0 (auto) must validate");
+}
+
+#[test]
+fn decoder_frame_size_limit_zero_ok() {
+    // 0 = "no limit", documented and accepted.
+    DecoderConfig::new()
+        .frame_size_limit(0)
+        .validate()
+        .expect("frame_size_limit=0 (no limit) must validate");
+}

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -3,10 +3,10 @@
 //! Each `ValidationError` variant gets one synthetic config that
 //! triggers it; default-constructed configs must always validate.
 
-use zenavif::{DecoderConfig, ValidationError};
+use zenavif::DecoderConfig;
 
 #[cfg(feature = "encode")]
-use zenavif::EncoderConfig;
+use zenavif::{EncoderConfig, ValidationError};
 
 // --------------------------------------------------------------------
 // Happy paths


### PR DESCRIPTION
## Summary

- New `__expert` cargo feature exposes `expert::InternalParams` mirroring `zenravif::expert::InternalParams`.
- `EncoderConfig::with_internal_params(InternalParams)` fans the 4 fields out into ravif's setter via `build_ravif_encoder`.
- The 4 individual setters added in Phase 0.5 (`with_partition_range`, `with_complex_prediction_modes`, `with_lrf`, `with_fast_deblock`) are removed; never published.
- Theory-of-operation docs on every InternalParams field; cross-references zenravif's source-line citations.
- 12 tests in `tests/expert_internal_params.rs`: per-field permutations, idempotency, combined-knobs, default-as-baseline byte-equality, reset, and **forwarding-parity** (zenavif's wrapper produces byte-identical output to calling ravif directly).
- `cargo semver-checks check-release --baseline-version 0.1.6`: 196 pass, 0 breaking.

## Build dependency

`[patch.crates-io] zenravif` is **temporarily** pointed at `../ravif--expert/ravif` while imazen/cavif-rs#feat/expert-internal-params is unmerged. **Before merging this PR**, that PR must merge AND the patch path must revert to `../ravif/ravif` (or be dropped entirely once zenravif 0.1.3 publishes).

## Test plan
- [x] `cargo test --features __expert` — 106 tests pass
- [x] `cargo clippy --all-targets --features __expert -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo semver-checks check-release --baseline-version 0.1.6` — 196 pass, 0 breaking
- [ ] CI matrix on push (will need ravif--expert sibling cloned — see checkout-deps action)