### PR TITLE
fix: saturating arithmetic in stitch_tiles for inconsistent grid dims

### DIFF
--- a/src/decoder_managed.rs
+++ b/src/decoder_managed.rs
@@ -787,21 +787,17 @@ impl ManagedAvifDecoder {
         for (tile_idx, tile) in tile_images.iter().enumerate() {
             let row = tile_idx / cols;
             let col = tile_idx % cols;
-            let tile_w = tile.width() as usize;
-            let tile_h = tile.height() as usize;
-            let dst_x = col * tile_w;
-            let dst_y = row * tile_h;
-
-            let tile_slice = tile.as_slice();
-            let mut out_slice = output.as_slice_mut();
-            for y in 0..tile_h.min(output_height - dst_y) {
-                let src = tile_slice.row(y as u32);
-                let copy_w = tile_w.min(output_width - dst_x);
-                let copy_bytes = copy_w * bpp;
-                let dst_row = out_slice.row_mut((dst_y + y) as u32);
-                let dst_start = dst_x * bpp;
-                dst_row[dst_start..dst_start + copy_bytes].copy_from_slice(&src[..copy_bytes]);
-            }
+            let dst_x = col * tile.width() as usize;
+            let dst_y = row * tile.height() as usize;
+            stitch_tile_into_buffer(
+                tile,
+                &mut output,
+                dst_x,
+                dst_y,
+                output_width,
+                output_height,
+                bpp,
+            );
         }
 
         Ok(output)
@@ -1883,5 +1879,103 @@ impl AnimationDecoder {
     /// Index of the next frame that will be decoded (0-based).
     pub fn frame_index(&self) -> usize {
         self.frame_index
+    }
+}
+
+/// Copy one tile's pixels into the stitched grid output buffer.
+///
+/// Uses `saturating_sub` for the available width/height so a malformed AVIF
+/// whose declared `output_width`/`output_height` are smaller than the actual
+/// tile placement (`dst_x`/`dst_y`) does not trigger a usize underflow panic.
+/// Tiles that fall entirely outside the declared output area are silently
+/// skipped (zero-length copy range).
+fn stitch_tile_into_buffer(
+    tile: &PixelBuffer,
+    output: &mut PixelBuffer,
+    dst_x: usize,
+    dst_y: usize,
+    output_width: usize,
+    output_height: usize,
+    bpp: usize,
+) {
+    let tile_w = tile.width() as usize;
+    let tile_h = tile.height() as usize;
+
+    // Saturating arithmetic: if the tile's destination origin lies outside the
+    // declared output dimensions, avail_* is 0 and we skip the copy entirely.
+    // Bailing out also avoids indexing the destination row at `dst_x * bpp`
+    // when `dst_x >= output_width` (which would still panic even though
+    // copy_bytes is 0, because the slice index range start is out of bounds).
+    let avail_h = output_height.saturating_sub(dst_y);
+    let avail_w = output_width.saturating_sub(dst_x);
+    if avail_h == 0 || avail_w == 0 {
+        return;
+    }
+
+    let tile_slice = tile.as_slice();
+    let mut out_slice = output.as_slice_mut();
+    for y in 0..tile_h.min(avail_h) {
+        let src = tile_slice.row(y as u32);
+        let copy_w = tile_w.min(avail_w);
+        let copy_bytes = copy_w * bpp;
+        let dst_row = out_slice.row_mut((dst_y + y) as u32);
+        let dst_start = dst_x * bpp;
+        dst_row[dst_start..dst_start + copy_bytes].copy_from_slice(&src[..copy_bytes]);
+    }
+}
+
+#[cfg(test)]
+mod stitch_tests {
+    use super::*;
+
+    fn make_buffer(w: u32, h: u32, fill: u8) -> PixelBuffer {
+        let descriptor = PixelDescriptor::RGBA8_SRGB;
+        let bpp = descriptor.bytes_per_pixel();
+        let data = vec![fill; (w as usize) * (h as usize) * bpp];
+        PixelBuffer::from_vec(data, w, h, descriptor).expect("buffer alloc")
+    }
+
+    /// Regression test for the H1 finding: a crafted AVIF where a grid tile's
+    /// destination origin (dst_x/dst_y) exceeds the declared output dimensions
+    /// must not panic with a usize underflow. Before the fix, computing
+    /// `output_height - dst_y` underflowed and panicked.
+    #[test]
+    fn stitch_does_not_panic_when_tile_origin_exceeds_output() {
+        let tile = make_buffer(64, 64, 0xAB);
+        let mut output = make_buffer(32, 32, 0);
+        // dst_y > output_height — would underflow without saturating_sub.
+        stitch_tile_into_buffer(&tile, &mut output, 0, 64, 32, 32, 4);
+        // Output buffer untouched, no panic.
+        assert_eq!(output.as_slice().row(0)[0], 0);
+    }
+
+    #[test]
+    fn stitch_does_not_panic_when_tile_x_exceeds_output() {
+        let tile = make_buffer(64, 64, 0xCD);
+        let mut output = make_buffer(32, 32, 0);
+        // dst_x > output_width — would underflow without saturating_sub.
+        stitch_tile_into_buffer(&tile, &mut output, 64, 0, 32, 32, 4);
+        assert_eq!(output.as_slice().row(0)[0], 0);
+    }
+
+    /// A tile whose origin is exactly at the output edge contributes nothing
+    /// (avail_* == 0) but must not panic.
+    #[test]
+    fn stitch_zero_avail_at_exact_edge() {
+        let tile = make_buffer(16, 16, 0xEE);
+        let mut output = make_buffer(32, 32, 0);
+        stitch_tile_into_buffer(&tile, &mut output, 32, 0, 32, 32, 4);
+        stitch_tile_into_buffer(&tile, &mut output, 0, 32, 32, 32, 4);
+        assert_eq!(output.as_slice().row(0)[0], 0);
+    }
+
+    /// Sanity check: a normally-placed tile still gets copied.
+    #[test]
+    fn stitch_copies_within_bounds() {
+        let tile = make_buffer(8, 8, 0x42);
+        let mut output = make_buffer(16, 16, 0);
+        stitch_tile_into_buffer(&tile, &mut output, 0, 0, 16, 16, 4);
+        // First row, first pixel byte should now be 0x42.
+        assert_eq!(output.as_slice().row(0)[0], 0x42);
     }
 }


### PR DESCRIPTION
## Summary

Security audit finding **H1** (HIGH): reachable `usize` underflow panic in the buffered grid-stitch path.

`src/decoder_managed.rs:797-799` (pre-fix) computed `output_height - dst_y` and `output_width - dst_x` with plain subtraction. A crafted AVIF whose `GridConfig.output_width` / `output_height` are inconsistent with the actual AV1 tile dimensions (e.g. a 2x2 grid of 64x64 tiles declaring `output_height = 32`) places a tile origin outside the declared output box, underflows `usize`, and panics.

The streaming paths (`decode_grid_to_sink` in this file and `codec.rs:2615/2657`) already used `saturating_sub`; only the buffered `stitch_tiles` path was vulnerable.

### Fix

- Extracted the per-tile copy into a free helper `stitch_tile_into_buffer`.
- `output_height.saturating_sub(dst_y)` / `output_width.saturating_sub(dst_x)`.
- Early-return when `avail_h == 0 || avail_w == 0`. The early-return is necessary on top of `saturating_sub` because `dst_x >= output_width` would still panic at the destination row index range start even when `copy_bytes == 0`.

### File

- `src/decoder_managed.rs:787-801` (call site) and `src/decoder_managed.rs:1888-1923` (helper).

## Test plan

- [x] New unit tests in `decoder_managed::stitch_tests` cover:
  - tile origin past the bottom edge (would underflow without fix)
  - tile origin past the right edge (would panic at row index even with `saturating_sub` alone)
  - exactly-at-edge case (`avail_* == 0`)
  - normal in-bounds copy as a sanity baseline
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --all-targets` all green
- [x] `cargo test --doc` all green