### PR TITLE
fix(hdr): correct zenavif mdcv mastering-display scale to ST 2086 (#45)

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -581,8 +581,11 @@ impl zencodec::encode::EncodeJob for AvifEncodeJob {
             );
         }
         if let Some(mdcv) = self.mastering_display {
-            // Convert from f32 CIE xy (0.0–1.0) to 0.16 fixed-point (u16)
-            let xy_to_u16 = |v: f32| (v * 65535.0 + 0.5) as u16;
+            // ST 2086 (the mdcv box): f32 CIE xy (0.0–1.0) → 0.00002 units
+            // (×50000), u16, stored verbatim by ravif/the box; the decoder
+            // reads ×0.00002. (Was ×65535 — off by 1.31× vs spec, and broke
+            // round-trip against our own decoder.)
+            let xy_to_u16 = |v: f32| (v * 50000.0 + 0.5) as u16;
             config = config.mastering_display(crate::MasteringDisplayConfig {
                 primaries: [
                     (
@@ -602,10 +605,10 @@ impl zencodec::encode::EncodeJob for AvifEncodeJob {
                     xy_to_u16(mdcv.white_point_xy[0]),
                     xy_to_u16(mdcv.white_point_xy[1]),
                 ),
-                // 24.8 fixed-point: multiply by 256
-                max_luminance: (mdcv.max_luminance * 256.0 + 0.5) as u32,
-                // 18.14 fixed-point: multiply by 16384
-                min_luminance: (mdcv.min_luminance * 16384.0 + 0.5) as u32,
+                // ST 2086: cd/m² → 0.0001 units (×10000). (Was ×256.)
+                max_luminance: (mdcv.max_luminance * 10000.0 + 0.5) as u32,
+                // ST 2086: cd/m² → 0.0001 units (×10000). (Was ×16384.)
+                min_luminance: (mdcv.min_luminance * 10000.0 + 0.5) as u32,
             });
         }
         // Apply rotation/mirror from orientation metadata

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -115,19 +115,23 @@ pub enum EncodeChromaSubsampling {
     Yuv420,
 }
 
-/// Mastering display metadata for HDR encoding (SMPTE ST 2086)
+/// Mastering display metadata for HDR encoding (SMPTE ST 2086).
 ///
-/// All chromaticity values are in CIE 1931 0.16 fixed-point (0–65535 maps to 0.0–1.0).
-/// Luminance values use 24.8 (max) and 18.14 (min) fixed-point encoding.
+/// Fields are in the **`mdcv` box units** — they are written verbatim into the
+/// MP4 `mdcv` box and read back the same way, so they must already be ST-2086
+/// scaled (do NOT use 0.16/24.8/18.14 fixed-point — that earlier doc was wrong
+/// and produced ~1.31×/39× errors against compliant readers):
+/// - chromaticity x/y: CIE 1931 in **0.00002 units** (multiply CIE xy by 50000)
+/// - luminance: in **0.0001 cd/m² units** (multiply cd/m² by 10000)
 #[derive(Debug, Clone, Copy)]
 pub struct MasteringDisplayConfig {
-    /// Chromaticity coordinates for red, green, blue primaries: [(x, y); 3]
+    /// R, G, B primary chromaticities `[(x, y); 3]`, in 0.00002 units (xy×50000).
     pub primaries: [(u16, u16); 3],
-    /// White point chromaticity (x, y)
+    /// White point chromaticity `(x, y)`, in 0.00002 units (xy×50000).
     pub white_point: (u16, u16),
-    /// Maximum display luminance (24.8 fixed-point cd/m²)
+    /// Maximum display luminance, in 0.0001 cd/m² units (cd/m²×10000).
     pub max_luminance: u32,
-    /// Minimum display luminance (18.14 fixed-point cd/m²)
+    /// Minimum display luminance, in 0.0001 cd/m² units (cd/m²×10000).
     pub min_luminance: u32,
 }
 

--- a/tests/metadata_roundtrip.rs
+++ b/tests/metadata_roundtrip.rs
@@ -171,11 +171,15 @@ fn content_light_level_roundtrip() {
 
 #[test]
 fn mastering_display_roundtrip() {
+    // `mdcv`-box units (ST 2086), written verbatim and read back the same:
+    // chroma ×50000 (here P3: green 0.265,0.690 → 13250,34500; D65 white),
+    // luminance ×10000. (This is a box-layout passthrough check — the cd/m²
+    // scaling lives in the zencodec adapter, exercised by an adapter round-trip.)
     let md_config = MasteringDisplayConfig {
         primaries: [(13250, 34500), (7500, 3000), (34000, 16000)],
         white_point: (15635, 16450),
-        max_luminance: 10000 << 8, // 10000 cd/m² in 24.8 fixed point
-        min_luminance: 50,         // ~0.003 cd/m² in 18.14 fixed point
+        max_luminance: 1000 * 10000, // 1000 cd/m² in 0.0001 units
+        min_luminance: 50,           // 0.005 cd/m² in 0.0001 units
     };
 
     let config = EncoderConfig::new()
@@ -188,7 +192,7 @@ fn mastering_display_roundtrip() {
         .mastering_display
         .expect("mastering display metadata should be present");
 
-    assert_eq!(mdcv.max_luminance, 10000 << 8);
+    assert_eq!(mdcv.max_luminance, 1000 * 10000);
     assert_eq!(mdcv.min_luminance, 50);
 }
 


### PR DESCRIPTION
**Real HDR-metadata corruption bug**, found by a per-codec spec audit (imazen/zenpixels#45).

The zencodec encode adapter wrote the `mdcv` (ST 2086) box with non-spec scale factors: chroma **×65535** (spec: ×50000), max_luminance **×256** and min_luminance **×16384** (spec: ×10000). Conformant readers (libavif, browsers) mis-scaled mastering luminance by **~39×** and chroma by 1.31×, and it didn't round-trip against zenavif's *own* decoder (correct at ÷50000/÷10000).

**Verified:** ravif's `ChromaticityPoint` expects ST-2086 units — its own test encodes Display-P3 green (0.265,0.690) as (13250,34500)=×50000 — and stores it verbatim in the box. Fix: encode → ×50000 chroma / ×10000 luminance (still + animation paths); corrected the `MasteringDisplayConfig` doc (the wrong 0.16/24.8/18.14 doc was the root cause); de-misled the box-layout test.

Builds clean. Independently landable (pre-existing types). Follow-up: a zencodec-adapter cd/m² round-trip test.