### PR TITLE
fix(limits): default decode frame_size_limit to 120MP (closes #22 decode fail-open)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ the [zenrav1e](https://github.com/imazen/zenrav1e) encoder (our fork of
 
 ## [Unreleased]
 
+### Changed
+- **Decode is bounded by default (closes the decode fail-open part of #22).**
+  `DecoderConfig::default()` now defaults `frame_size_limit` to `120_000_000`
+  (120 MP, admits ~108 MP photos) instead of `0`. The pre-flight dimension
+  check (`decoder_managed.rs` / `decoder.rs`) only fires when the limit is
+  `> 0`, so `zenavif::decode(untrusted)` was previously unbounded by total
+  pixels; it now rejects over-120-MP frames with `Error::ImageTooLarge`
+  before any frame allocation. Non-breaking: `frame_size_limit(0)` still opts
+  out (unbounded), and the parser already inherits zenavif-parse's own caps
+  (512 MP / 1 GB peak). The frame-granularity cancellation sub-point of #22
+  stays open pending a rav1d-safe Stop hook.
+
 ### Added
 - **Calibrated resource-estimation module (`heuristics`).** New
   `zenavif::heuristics` with `EncodeEstimate` (min/typical/max peak memory +

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,10 @@ harness = false
 required-features = ["_dev"]
 
 [[example]]
+name = "avif_probe"
+required-features = ["encode"]
+
+[[example]]
 name = "mono_encode_ab"
 required-features = ["encode-imazen"]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,12 @@ pub struct DecoderConfig {
     pub(crate) threads: u32,
     /// Whether to apply film grain synthesis
     pub(crate) apply_grain: bool,
-    /// Maximum frame size limit in pixels (0 = no limit)
+    /// Maximum decoded frame size in total pixels (width * height).
+    ///
+    /// Enforced pre-flight against the container's declared dimensions, before
+    /// any decode work or frame allocation. Defaults to 120_000_000 (120 MP,
+    /// admits ~108 MP photos) so untrusted decode is bounded by default.
+    /// `0` is the explicit opt-out — no decode-side pixel limit.
     pub(crate) frame_size_limit: u32,
     /// CPU feature flags mask (bitwise AND with detected features).
     /// Use to disable SIMD paths for testing. Default: all enabled.
@@ -33,8 +38,17 @@ impl Default for DecoderConfig {
             // frame threading overhead.
             threads: 0,
             apply_grain: true,
-            frame_size_limit: 0,
+            // Bound untrusted decode by default: 120 MP (admits ~108 MP photos).
+            // The enforcement at `decoder_managed.rs` / `decoder.rs` only fires
+            // when this is > 0, so this default is what makes the pre-flight
+            // dimension check actually run for `decode()` / `DecoderConfig::default()`.
+            // Use `frame_size_limit(0)` to opt out (unbounded).
+            frame_size_limit: 120_000_000,
             cpu_flags_mask: u32::MAX,
+            // `None` here does NOT mean "unbounded": the parser is constructed
+            // from `zenavif_parse::DecodeConfig::default()`, which carries its
+            // own sane caps (512 MP / 1 GB peak / 10k frames / 1k tiles). These
+            // overrides only *tighten* below the parser's defaults when set.
             parser_peak_memory_limit: None,
             parser_total_megapixels_limit: None,
             parser_max_animation_frames: None,
@@ -68,8 +82,10 @@ impl DecoderConfig {
 
     /// Set maximum frame size limit in total pixels
     ///
-    /// If width * height exceeds this limit, decoding will fail.
-    /// 0 means no limit.
+    /// If width * height exceeds this limit, decoding fails pre-flight with
+    /// [`Error::ImageTooLarge`](crate::Error::ImageTooLarge) before any frame
+    /// is allocated. Defaults to `120_000_000` (120 MP). Pass `0` to opt out
+    /// (no decode-side pixel limit).
     pub fn frame_size_limit(mut self, limit: u32) -> Self {
         self.frame_size_limit = limit;
         self
@@ -101,5 +117,32 @@ impl DecoderConfig {
     pub fn prefer_8bit(mut self, prefer: bool) -> Self {
         self.prefer_8bit = prefer;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression for imazen/zenavif#22 (decode fail-open): the default decode
+    /// pixel cap must be 120 MP, not `0` (unbounded). Because the pre-flight
+    /// dimension check in `decoder_managed.rs` / `decoder.rs` only fires when
+    /// `frame_size_limit > 0`, a `0` default left untrusted `decode()` unbounded.
+    #[test]
+    fn default_frame_size_limit_is_120mp_not_unbounded() {
+        assert_eq!(
+            DecoderConfig::default().frame_size_limit,
+            120_000_000,
+            "default decode frame_size_limit must be 120 MP so untrusted decode is bounded (zenavif#22)"
+        );
+        assert_eq!(DecoderConfig::new().frame_size_limit, 120_000_000);
+    }
+
+    /// The explicit opt-out must still work: `frame_size_limit(0)` disables the
+    /// decode-side pixel cap (preserves the documented `0 = unlimited` escape).
+    #[test]
+    fn frame_size_limit_zero_opts_out() {
+        let cfg = DecoderConfig::default().frame_size_limit(0);
+        assert_eq!(cfg.frame_size_limit, 0, "0 must remain the explicit opt-out");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,6 +143,9 @@ mod tests {
     #[test]
     fn frame_size_limit_zero_opts_out() {
         let cfg = DecoderConfig::default().frame_size_limit(0);
-        assert_eq!(cfg.frame_size_limit, 0, "0 must remain the explicit opt-out");
+        assert_eq!(
+            cfg.frame_size_limit, 0,
+            "0 must remain the explicit opt-out"
+        );
     }
 }

--- a/tests/decode_frame_size_limit.rs
+++ b/tests/decode_frame_size_limit.rs
@@ -7,8 +7,8 @@
 //! *below* the fixture's 15 px to prove the same mechanism the 120 MP default
 //! arms; and we confirm `0` still opts out (decodes unbounded).
 
-use zenavif::{DecoderConfig, Error, decode_with};
 use enough::Unstoppable;
+use zenavif::{DecoderConfig, Error, decode_with};
 
 /// 5x3 (= 15 px) genuine monochrome AVIF, the smallest committed fixture.
 const MONO_5X3: &str = "tests/vectors/zenavif/mono_5x3_8b_full.avif";
@@ -23,7 +23,11 @@ fn over_limit_dimensions_rejected_preflight() {
     let data = std::fs::read(MONO_5X3).expect("fixture");
 
     // Sanity: with no cap the fixture decodes fine.
-    let ok = decode_with(&data, &DecoderConfig::new().frame_size_limit(0), &Unstoppable);
+    let ok = decode_with(
+        &data,
+        &DecoderConfig::new().frame_size_limit(0),
+        &Unstoppable,
+    );
     assert!(ok.is_ok(), "5x3 fixture must decode with the cap disabled");
 
     // Cap of 1 px < the fixture's pixel count → pre-flight rejection.
@@ -50,8 +54,12 @@ fn over_limit_dimensions_rejected_preflight() {
 #[test]
 fn zero_limit_opts_out_of_preflight() {
     let data = std::fs::read(MONO_5X3).expect("fixture");
-    let out = decode_with(&data, &DecoderConfig::new().frame_size_limit(0), &Unstoppable)
-        .expect("0 must opt out of the decode-side pixel cap");
+    let out = decode_with(
+        &data,
+        &DecoderConfig::new().frame_size_limit(0),
+        &Unstoppable,
+    )
+    .expect("0 must opt out of the decode-side pixel cap");
     assert_eq!((out.width(), out.height()), (5, 3));
 }
 

--- a/tests/decode_frame_size_limit.rs
+++ b/tests/decode_frame_size_limit.rs
@@ -1,0 +1,67 @@
+//! Pre-flight decode pixel-cap enforcement — imazen/zenavif#22 (decode fail-open).
+//!
+//! `DecoderConfig::default()` now defaults `frame_size_limit` to 120 MP so
+//! untrusted `decode()` is bounded. These tests exercise the pre-flight
+//! dimension check (`decoder_managed.rs` rejects before any frame allocation)
+//! with a tiny real 5x3 AVIF — we never allocate a 120 MP frame. We set a cap
+//! *below* the fixture's 15 px to prove the same mechanism the 120 MP default
+//! arms; and we confirm `0` still opts out (decodes unbounded).
+
+use zenavif::{DecoderConfig, Error, decode_with};
+use enough::Unstoppable;
+
+/// 5x3 (= 15 px) genuine monochrome AVIF, the smallest committed fixture.
+const MONO_5X3: &str = "tests/vectors/zenavif/mono_5x3_8b_full.avif";
+
+/// A cap below the fixture's pixel count must reject pre-flight with
+/// `ImageTooLarge`. This is the exact mechanism the 120 MP default arms,
+/// proven without allocating an over-120-MP frame. The cap is `1` so the
+/// rejection is robust whether the pre-flight reads the 5x3 display size or
+/// the AV1 coded size (either way > 1 px).
+#[test]
+fn over_limit_dimensions_rejected_preflight() {
+    let data = std::fs::read(MONO_5X3).expect("fixture");
+
+    // Sanity: with no cap the fixture decodes fine.
+    let ok = decode_with(&data, &DecoderConfig::new().frame_size_limit(0), &Unstoppable);
+    assert!(ok.is_ok(), "5x3 fixture must decode with the cap disabled");
+
+    // Cap of 1 px < the fixture's pixel count → pre-flight rejection.
+    let cfg = DecoderConfig::new().frame_size_limit(1);
+    let err = decode_with(&data, &cfg, &Unstoppable)
+        .expect_err("a multi-pixel frame must be rejected against a 1 px cap");
+    // The load-bearing assertion: rejected with ImageTooLarge before decode.
+    // Reported dims are the container's declared size; assert they're the
+    // expected 5x3 but don't hinge the test on exact coded-vs-display padding.
+    match err.error() {
+        Error::ImageTooLarge { width, height } => {
+            assert!(
+                (*width as u64) * (*height as u64) > 1,
+                "rejected dims {width}x{height} must exceed the 1 px cap"
+            );
+        }
+        other => panic!("expected ImageTooLarge, got {other:?}"),
+    }
+}
+
+/// `frame_size_limit(0)` keeps the documented opt-out: a frame larger than the
+/// 120 MP default still decodes when the caller explicitly disables the cap.
+/// (The 5x3 fixture is well under 120 MP; this asserts `0` does not reject.)
+#[test]
+fn zero_limit_opts_out_of_preflight() {
+    let data = std::fs::read(MONO_5X3).expect("fixture");
+    let out = decode_with(&data, &DecoderConfig::new().frame_size_limit(0), &Unstoppable)
+        .expect("0 must opt out of the decode-side pixel cap");
+    assert_eq!((out.width(), out.height()), (5, 3));
+}
+
+/// The default config now carries the 120 MP cap (would reject a >120 MP
+/// frame). The 5x3 fixture is far under it, so the default decodes it — this
+/// guards that the new default doesn't reject normal images.
+#[test]
+fn default_config_decodes_normal_image() {
+    let data = std::fs::read(MONO_5X3).expect("fixture");
+    let out = decode_with(&data, &DecoderConfig::default(), &Unstoppable)
+        .expect("normal 5x3 image must decode under the 120 MP default cap");
+    assert_eq!((out.width(), out.height()), (5, 3));
+}


### PR DESCRIPTION
Closes the **decode fail-open** part of #22.

## The bug
`DecoderConfig::default()` had `frame_size_limit: 0`. The pre-flight dimension check (`decoder_managed.rs:151-163`, and the legacy FFI path `decoder.rs:572-574`) only fires when `frame_size_limit > 0`, so `zenavif::decode(untrusted)` / `DecoderConfig::default()` had **no total-pixel bound** — only `checked_mul` overflow protection. A crafted giant-resolution AVIF could allocate unbounded.

## The fix (non-breaking)
Default `frame_size_limit` to `120_000_000` (120 MP, admits ~108 MP photos — the house fleet default), so the **existing** enforcement actually fires by default. `0` is preserved as the explicit opt-out (unbounded), documented on both the field and the `frame_size_limit()` builder.

This only changes a default value; no signature or API change. Both the managed and legacy-FFI decode paths read the same field, so both are now bounded by default.

Note on the parser limits: the `parser_*` fields stay `None`. `None` there does **not** mean unbounded — the parser is built from `zenavif_parse::DecodeConfig::default()`, which already carries its own caps (512 MP / 1 GB peak / 10k frames / 1k tiles). So the only genuine fail-open at the zenavif layer was `frame_size_limit`, and that is what this PR fixes.

## Tests
- `src/config.rs` unit tests: `default_frame_size_limit_is_120mp_not_unbounded` (asserts the default is `120_000_000`, not `0`, for both `default()` and `new()`); `frame_size_limit_zero_opts_out` (asserts `frame_size_limit(0)` still sets `0`).
- `tests/decode_frame_size_limit.rs`: decodes the committed 284-byte 5x3 fixture (`mono_5x3_8b_full.avif`, 15 px) and asserts that a sub-pixel-count cap (`1`) is **rejected pre-flight with `Error::ImageTooLarge`** — exercising the exact `decoder_managed.rs:151-163` path the 120 MP default arms, **without allocating a 120 MP frame**. Also asserts `frame_size_limit(0)` opts out (decodes), and that `DecoderConfig::default()` decodes a normal image (the new default does not reject ordinary sizes).

## Still open
The **frame-granularity cancellation** sub-point of #22 (a single huge frame cannot be interrupted mid-decode because rav1d-safe has no cancellation hook — see rav1d-safe#412) remains tracked in #22; it is rav1d-safe-dependent and out of scope here.