### PR TITLE
test(heaptrack): add a decode allocation-profiling harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ the [zenrav1e](https://github.com/imazen/zenrav1e) encoder (our fork of
   stays open pending a rav1d-safe Stop hook.
 
 ### Added
+- `examples/heaptrack_decode.rs`: a reusable heaptrack/valgrind harness that
+  decodes an AVIF file from bytes via `zenavif::decode(..)` in a loop, for
+  profiling heap-allocation behaviour. Defaults to the committed
+  `tests/vectors/libavif/kodim03_yuv420_8bpc.avif` (768×512, 4:2:0 8-bit) decoded
+  8×; a path + iteration count can be passed. Driven by `just heaptrack-decode`.
+  Profiled result: heap **size** and leaks are healthy — peak 2.41 MiB (O(image)),
+  leaked pinned at ~28 across 2/8/16 iterations (one-time thread-pool statics, no
+  per-decode growth). Allocation **count** is a pathology — ~37,000/decode, of
+  which 99% are transient (0 B net) and concentrated in the **rav1d-safe** backend:
+  `compact_read_per_row` (325,917 total across 9 decodes) stages a strided plane
+  region into a fresh contiguous heap buffer per CDEF/loopfilter/intra-pred block.
+  The churn originates in the rav1d-safe dependency's safe-SIMD filter path, not
+  in zenavif's own container/YUV code. Tracked as a resource follow-up.
 - **Calibrated resource-estimation module (`heuristics`).** New
   `zenavif::heuristics` with `EncodeEstimate` (min/typical/max peak memory +
   `time_ms` + `output_bytes`), `DecodeEstimate` (peak memory + time +

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,11 @@ required-features = ["__expert"]
 name = "auto_tune_smoke"
 required-features = ["auto-tune"]
 
+# Heaptrack allocation-profiling harness for the decode-from-bytes path.
+# Decode is in the default feature set (pure-Rust rav1d-safe); no extra features.
+[[example]]
+name = "heaptrack_decode"
+
 [features]
 default = []
 # Decode with hand-written assembly via C FFI (fastest, uses unsafe)

--- a/examples/heaptrack_decode.rs
+++ b/examples/heaptrack_decode.rs
@@ -1,0 +1,88 @@
+//! Heaptrack harness for AVIF decode-from-bytes allocation profiling.
+//!
+//! Profiles the production-critical path: `zenavif::decode(&bytes)` — decoding an
+//! AVIF file (untrusted input) all the way to a `PixelBuffer`, via the default
+//! pure-Rust rav1d-safe AV1 backend. The goal is to surface allocation
+//! *pathologies* that don't show up in a wall-clock benchmark: a high allocation
+//! *count* relative to image size, per-pixel or per-block/per-tile mallocs, large
+//! transient peaks, or unbounded growth across repeated decodes (a leak). High
+//! allocation churn hurts most under contended allocators (Windows, multi-threaded
+//! servers) where a single decode of an untrusted upload turns into thousands of
+//! lock round-trips.
+//!
+//! NOTE: the AV1 decode work is done by `rav1d-safe` (a safe Rust port of dav1d),
+//! so the bulk of the allocation call-sites originate in that dependency; zenavif
+//! owns the container parse (zenavif-parse) and the YUV->RGB conversion buffers.
+//!
+//! Usage:
+//!   cargo build -p zenavif --release --example heaptrack_decode
+//!   heaptrack ./target/release/examples/heaptrack_decode                 # default fixture
+//!   heaptrack ./target/release/examples/heaptrack_decode <file.avif> [iters]
+//!
+//! Then inspect:
+//!   heaptrack_print heaptrack.heaptrack_decode.*.zst | less
+//!
+//! Defaults to the committed `tests/vectors/libavif/kodim03_yuv420_8bpc.avif`
+//! (768x512 Kodak photo, 4:2:0 8-bit — a meaningful AV1 superblock/tile count for
+//! judging the allocation count) decoded 8 times. A large fixture should be
+//! decoded fewer times (pass a smaller `iters`).
+
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+
+/// Resolve the default bundled fixture relative to the crate manifest so the
+/// example runs from any working directory.
+fn default_fixture() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/vectors/libavif/kodim03_yuv420_8bpc.avif")
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    let path: PathBuf = match args.get(1) {
+        Some(p) => PathBuf::from(p),
+        None => default_fixture(),
+    };
+    // Default 8 iterations; a leak shows up as monotonic growth across them, and a
+    // healthy decoder's steady-state per-decode allocation count is iterations-stable.
+    let iters: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(8);
+
+    let data = std::fs::read(&path).unwrap_or_else(|e| {
+        eprintln!("failed to read {}: {e}", path.display());
+        std::process::exit(1);
+    });
+
+    // Decode once up front to report the dimensions the alloc count is relative to.
+    {
+        let probe = zenavif::decode(&data).unwrap_or_else(|e| {
+            eprintln!("probe decode failed for {}: {e}", path.display());
+            std::process::exit(1);
+        });
+        let (w, h) = (probe.width(), probe.height());
+        eprintln!("fixture: {} ({} bytes on disk)", path.display(), data.len());
+        eprintln!(
+            "  decoded image: {}x{} ({:.2} MP)",
+            w,
+            h,
+            (f64::from(w) * f64::from(h)) / 1.0e6
+        );
+    }
+
+    eprintln!("decoding {iters}x via zenavif::decode(..) ...");
+
+    let mut total_pixels: u64 = 0;
+    for i in 0..iters {
+        let buf = zenavif::decode(&data).unwrap_or_else(|e| {
+            eprintln!("decode iteration {i} failed: {e}");
+            std::process::exit(1);
+        });
+        total_pixels += u64::from(buf.width()) * u64::from(buf.height());
+        // Consume the decoded buffer so the optimizer can't elide the decode or the
+        // allocation of the output PixelBuffer.
+        black_box(buf.width());
+        black_box(buf.height());
+        black_box(&buf);
+    }
+
+    eprintln!("done: decoded {total_pixels} total pixels across {iters} iterations");
+}

--- a/justfile
+++ b/justfile
@@ -63,6 +63,14 @@ decode-test:
     mkdir -p /mnt/v/output/zenavif/test
     cargo run --release --example decode_avif -- {{justfile_directory()}}/../../aom-decode/tests/test.avif /mnt/v/output/zenavif/test/test.png
 
+# Profile decode-from-bytes heap allocations with heaptrack (needs heaptrack installed).
+# Defaults to the committed kodim03_yuv420_8bpc.avif (768x512) decoded 8x; pass a path +
+# iters to override. Inspect with: heaptrack_print /tmp/zenavif-ht.zst
+heaptrack-decode *ARGS:
+    cargo build -p zenavif --release --example heaptrack_decode
+    rm -f /tmp/zenavif-ht.zst
+    heaptrack --output /tmp/zenavif-ht ./target/release/examples/heaptrack_decode {{ARGS}}
+
 # Cross-test i686 (32-bit x86)
 test-i686:
     cross test --target i686-unknown-linux-gnu


### PR DESCRIPTION
Adds a reusable `examples/heaptrack_decode.rs` for profiling the **decode-from-untrusted-bytes** heap-allocation behaviour under heaptrack/valgrind, mirroring the harness now in `heic`/`zenjpeg`/`zenpng`. It decodes an AVIF file via the public `zenavif::decode(..)` in a loop (default 8x), accepts a `<path> [iters]` override, and is driven by `just heaptrack-decode`.

Default fixture: the committed `tests/vectors/libavif/kodim03_yuv420_8bpc.avif` (768x512 Kodak photo, 4:2:0 8-bit -> meaningful AV1 superblock/tile count). The default pure-Rust rav1d-safe backend is exercised.

## Profiled result (heaptrack 1.3.0, release, no target-cpu=native)

| metric | value | note |
|---|---|---|
| peak heap | **2.41 MiB** | O(image) (output ~1.6 MiB), **healthy** |
| total alloc count | **330,705** (~37,000/decode) | **pathology** (see below) |
| temporary allocs | 259,857 (~79% of all allocs) | very high transient churn |
| leaked | 22.4 KiB / **~28 allocs** | **one-time statics** (see leak test) |
| total runtime | 0.56 s | |

**Heap size and leaks are healthy.** Peak is bounded and O(image). The leak is **not per-decode**: leaked-allocation count is ~28 at 2, 8, and 16 iterations (total allocs scale linearly: 110,280 / 330,705 / 624,646 = ~37k/decode), so it's one-time thread-pool/static init, not unbounded growth.

**Allocation count is a pathology, originating in the rav1d-safe backend (not zenavif's own code).** 99% of allocations come from a single rav1d-safe call-site:

- `rav1d_safe::...::compact_read_per_row` -> **325,917 allocs (across 9 decodes), 0 B net peak** — stages a strided plane region into a fresh contiguous heap buffer per filter invocation. Call path: `rav1d_filter_sbrow_cdef` -> `rav1d_cdef_brow` -> `cdef_direct` -> `compact_read_per_row` (also reached from the loopfilter and intra-pred safe-SIMD paths, `rav1d-safe/src/safe_simd/{loopfilter,ipred}.rs`).

zenavif's container parse (zenavif-parse) and YUV->RGB conversion do not contribute meaningfully. Tracked as a resource follow-up (the fix belongs upstream in rav1d-safe): #25.

run-heavy: build peak-RSS 1.02 GiB / min-avail 49004 MiB; heaptrack run peak-RSS 0.12 GiB / min-avail 51403 MiB.
