### PR TITLE
feat(error): adopt zencodec CategorizedError taxonomy (#103 final API); make zencodec required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,6 @@ jobs:
         run: cargo test
       - name: Test (no default features)
         run: cargo test --no-default-features
-      - name: Test (zencodec feature)
-        run: cargo test --features zencodec
 
   feature-check:
     name: Feature permutations
@@ -60,8 +58,6 @@ jobs:
         run: cargo check
       - name: Check --no-default-features
         run: cargo check --no-default-features
-      - name: Check --features zencodec
-        run: cargo check --features zencodec
 
   i686:
     name: Test (i686 cross)
@@ -76,6 +72,22 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: cross-i686
+      # zencodec integration is now always built, so the decode-correctness
+      # integration tests (cov_zencodec, color_context_decode) run here too and
+      # read downloaded vectors. Provision them (the cross container mounts the
+      # workspace, so host-downloaded tests/vectors is visible in-container).
+      - name: Cache test vectors
+        id: vectors-cache
+        uses: actions/cache@v5
+        with:
+          path: tests/vectors
+          key: avif-test-vectors-${{ hashFiles('scripts/download-avif-test-vectors.sh', 'scripts/download-linku-samples.sh') }}
+      - name: Download test vectors
+        if: steps.vectors-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          bash scripts/download-avif-test-vectors.sh
+          bash scripts/download-linku-samples.sh
       - name: Test (i686)
         # Mount the workspace parent so cross's Docker container can
         # see the cloned ../ravif and ../zenanalyze path-deps. Without
@@ -96,8 +108,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Clippy (default)
         run: cargo clippy --lib --tests --examples -- -D warnings
-      - name: Clippy (zencodec)
-        run: cargo clippy --lib --tests --examples --features zencodec -- -D warnings
 
   fmt:
     name: Format
@@ -134,6 +144,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: Swatinem/rust-cache@v2
+      # llvm-cov runs the integration tests; the now-always-built zencodec
+      # decode tests read downloaded vectors, so provision them here too.
+      - name: Cache test vectors
+        id: vectors-cache
+        uses: actions/cache@v5
+        with:
+          path: tests/vectors
+          key: avif-test-vectors-${{ hashFiles('scripts/download-avif-test-vectors.sh', 'scripts/download-linku-samples.sh') }}
+      - name: Download test vectors
+        if: steps.vectors-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          bash scripts/download-avif-test-vectors.sh
+          bash scripts/download-linku-samples.sh
       - name: Generate coverage
         run: cargo llvm-cov --lcov --output-path lcov.info
       - name: Upload coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,23 @@ the [zenrav1e](https://github.com/imazen/zenrav1e) encoder (our fork of
   branch until both release. Additive (`#[non_exhaustive]` enum + opt-in trait).
 
 ### Changed
+- **zencodec trait impls return the `At<CodecError>` envelope (Pattern B).** Every
+  `zencodec` trait method (`EncoderConfig`/`EncodeJob`/`Encoder`/`AnimationFrameEncoder`
+  + `DecoderConfig`/`DecodeJob`/`Decode`/`StreamingDecode`/`AnimationFrameDecoder`)
+  now declares `type Error = whereat::At<zencodec::CodecError>` instead of
+  `At<Error>`. A generic consumer driving zenavif through `Dyn*` dispatch — where
+  the error is erased to `Box<dyn Error + Send + Sync>` — now recovers the coarse
+  `ErrorCategory` **and** the `"zenavif"` codec name via `CodecErrorExt`
+  (`error_category()` / `codec_error()`), which return `None` under the previous
+  native-error type. The native `Error` enum (the detail + category source, with
+  its `CategorizedError` impl including the `Parse` delegation) is **unchanged**,
+  and zenavif's inherent rich public API still returns `At<Error>` for direct
+  callers — only the zencodec trait boundary changed. Internally each trait method
+  keeps its verbatim logic in a private `*_inner` helper returning `At<Error>` and
+  re-wraps once at the boundary with `CodecError::of` (already-located errors,
+  trace preserved) or the new `From<Error> for At<CodecError>` bridge (bare errors
+  at reject / sink-wrap sites). Additive at the type level; visible only to
+  generic `zencodec`-trait consumers.
 - **`zencodec` is now a required (non-optional) dependency.** The optional
   `zencodec` cargo feature is removed; the codec-trait integration is always
   built (the `codec` module implementing `Encoder`/`Decoder` +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,49 @@ the [zenrav1e](https://github.com/imazen/zenrav1e) encoder (our fork of
 ## [Unreleased]
 
 ### Added
+- **Adopt the `zencodec` `CategorizedError` taxonomy (PR #103, final API).**
+  `Error` now `impl zencodec::CategorizedError` with
+  `codec_name() == Some("zenavif")` — a `&self` method (not an associated const,
+  so the trait stays dyn-compatible) — and an exhaustive `category()` mapping
+  every variant to one coarse `zencodec::ErrorCategory`, so consumers route on
+  the category (HTTP status, retry policy, logging) without naming the enum. The
+  `Parse` arm **delegates** to `zenavif_parse::Error`'s own `CategorizedError`
+  (zenavif-parse PR #17): a malformed container stays `MalformedImage`, a
+  truncated one `UnexpectedEof`, a parser cap `LimitsExceeded`. Other arms:
+  `Unsupported` → `UnsupportedImageFeature`; `ImageTooLarge` →
+  `LimitsExceeded(Pixels)`; `ResourceLimit` → `LimitsExceeded(Memory)` (the
+  `String` variant is a catch-all, so a representative kind is reported, with
+  the precise limit in `Display`); `OutOfMemory` → `OutOfMemory`;
+  `Cancelled(r)` → `r.category()`; `UnsupportedOperation(op)` → `op.category()`;
+  `Decode` / `ColorConversion` (foreign `yuv`) / `Encode` → `Internal`. `Decode`
+  is a grab-bag the decode pipeline reuses for decoder setup/flush faults and
+  internal invariant checks (e.g. "expected 8-bit planes") as well as some
+  malformed-input cases; with no structural signal to split it, the conservative
+  `Internal` is its best single category. Behind a **temporary
+  `[patch.crates-io]` pin** to the unreleased `zencodec` `cancellation-
+  classification-99` branch + the `zenavif-parse` `caterr-categorized-error`
+  branch until both release. Additive (`#[non_exhaustive]` enum + opt-in trait).
+
+### Changed
+- **`zencodec` is now a required (non-optional) dependency.** The optional
+  `zencodec` cargo feature is removed; the codec-trait integration is always
+  built (the `codec` module implementing `Encoder`/`Decoder` +
+  `SourceEncodingDetails`, the `CategorizedError` impl, and
+  `From<zencodec::AllocPreference>`). `ultrahdr-core` (gain-map `ReconstructHdr`
+  math, previously pulled only by the `zencodec` feature) becomes a hard dep for
+  the same reason. The `cov_zencodec` / `color_context_decode` / `mono_decode` /
+  `gainmap_decode` integration tests are ungated (they run under default
+  `cargo test`); CI drops the now-redundant `--features zencodec`
+  test/check/clippy steps and provisions the downloaded AVIF vectors in the
+  `i686` and `coverage` jobs, which now run those decode tests.
+- **Migrate to zenavif-parse 0.6.x `whereat::At<Error>` Result API.** zenavif-parse
+  now returns `whereat::At<Error>` (location-tracing) from its parser entry points;
+  zenavif's parse-error boundaries (`decoder_managed.rs`, `decoder.rs`,
+  `detect.rs`) switch to the trace-preserving `ResultAtExt::map_err_at(Error::Parse)`
+  / `At::map_error(Error::Parse)` (and `e.error()` for the probe-classification
+  match) instead of dropping-and-rewrapping the inner error. Required to consume
+  zenavif-parse's `CategorizedError`. Decode output is unchanged (error-path only).
+
 - **Honor `zencodec::AllocPreference` at zenavif's own decode allocations.**
   The full-image RGB(A) output buffer, the grid-stitch canvas, the crop
   destination, and the per-row YUV→RGB scratch now route through a 3-mode,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,9 +1908,8 @@ dependencies = [
 
 [[package]]
 name = "zenavif-parse"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ea3a5640719078e3d91e5feab60dd5d7cff3c34bf5c666925044745c58569d"
+version = "0.6.3"
+source = "git+https://github.com/imazen/zenavif-parse?branch=caterr-categorized-error#2e938c37ef6abcb36788d111027a3edc1fa0986b"
 dependencies = [
  "arrayvec",
  "bitreader",
@@ -1919,6 +1918,7 @@ dependencies = [
  "fallible_collections",
  "leb128",
  "log",
+ "whereat",
  "zencodec",
 ]
 
@@ -1948,8 +1948,7 @@ dependencies = [
 [[package]]
 name = "zencodec"
 version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9328427935f563e3cc12aaab76ad4afe946d1a60611a74047184682afc20ed"
+source = "git+https://github.com/imazen/zencodec?branch=cancellation-classification-99#2c7fb39840ed03c02423554f8fe621b07055267f"
 dependencies = [
  "almost-enough",
  "enough",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ rav1d-safe = { version = "0.5.3", default-features = false, features = ["bitdept
 archmage = { version = "0.9.15", features = ["macros"] }
 magetypes = { version = "0.9.15"}
 safe_unaligned_simd = "0.2.5"
-zenavif-parse = "0.6.0"
+# 0.6.3+: parser entry points return `whereat::At<Error>`, and `Error` impls
+# `zencodec::CategorizedError` (delegated from this crate's `Error::Parse`).
+zenavif-parse = "0.6.3"
 yuv = "0.8.12"
 imgref = "1.12.0"
 rgb = { version = "0.8.52", default-features = false, features = ["bytemuck"] }
@@ -42,10 +44,13 @@ zenanalyze = { version = "0.2.0", path = "../zenanalyze", optional = true, featu
 zenanalyze-api = { git = "https://github.com/imazen/zenanalyze", rev = "47b4d0f5f1abfff45a152e9a9f4de82fffd5afa6", optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
 almost-enough = { version = "0.4.3", default-features = false }
-zencodec = { version = "0.1.25", optional = true }
+# zencodec trait integration is always built (the `codec` module implementing
+# Encoder/Decoder + the `CategorizedError` taxonomy), so this is a hard dep.
+zencodec = { version = "0.1.25" }
 # Gain-map application math for GainMapRender::ReconstructHdr (decode-side
-# HDR reconstruction). Pure math, no codec engines.
-ultrahdr-core = { version = "0.5.0", default-features = false, optional = true }
+# HDR reconstruction). Pure math, no codec engines. Used unconditionally by the
+# (now always-built) `codec` module, so it is a hard dep too.
+ultrahdr-core = { version = "0.5.0", default-features = false }
 # zennode = { path = "../zennode/zennode", optional = true, default-features = false, features = ["derive"] }
 zenpixels = { version = "0.2.11", default-features = false, features = ["imgref", "rgb"] }
 zenpixels-convert = { version = "0.2.13", default-features = false, features = ["rgb"] }
@@ -187,8 +192,6 @@ __expert = ["encode-imazen", "ravif/__expert"]
 # model + zenanalyze feature extractor; adds ~30 KB to the binary.
 # See docs/RAV1E_PICKER_PLAN.md for the training pipeline.
 auto-tune = ["encode-imazen", "dep:zenpredict", "dep:zenanalyze", "dep:zenanalyze-api", "dep:serde_json"]
-# Enable zencodec trait integration
-zencodec = ["dep:zencodec", "zenavif-parse/zencodec", "dep:ultrahdr-core"]
 # Enable zennode pipeline node definitions
 # zennode = ["dep:zennode"]
 # Expose internal YUV conversion modules for profiling/debugging. Not public API.
@@ -200,3 +203,10 @@ opt-level = 2
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--generate-link-to-definition"]
+
+[patch.crates-io]
+# TEMP (both): until zencodec 0.1.26 ships (PR #103, adds the `CategorizedError`
+# taxonomy) AND zenavif-parse's CategorizedError adoption (PR #17) merges +
+# releases. Remove both patches and bump the version deps once those land.
+zencodec = { git = "https://github.com/imazen/zencodec", branch = "cancellation-classification-99" }
+zenavif-parse = { git = "https://github.com/imazen/zenavif-parse", branch = "caterr-categorized-error" }

--- a/src/alloc_util.rs
+++ b/src/alloc_util.rs
@@ -33,11 +33,13 @@ use crate::error::Error;
 
 /// Crate-local mirror of `zencodec::AllocPreference`.
 ///
-/// Kept independent of the optional `zencodec` dependency so the core decode
-/// path (which is always compiled) does not gain a hard `zencodec`
-/// dependency. The `codec` module converts from `zencodec::AllocPreference`
-/// via [`From`] at the trait boundary.
+/// Kept independent of the `zencodec` types so the core decode path stays
+/// decoupled from the codec-trait layer. The `codec` module converts from
+/// `zencodec::AllocPreference` via [`From`] at the trait boundary.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+// `Fallible` / `Infallible` are constructed from `zencodec::AllocPreference`
+// (the `From` impl below); the variants exist so `resolve_fallible`'s match
+// stays exhaustive.
 pub(crate) enum AllocPref {
     /// Let each call site keep its own default fallibility. Preserves existing
     /// behavior. This is the default.
@@ -52,7 +54,6 @@ pub(crate) enum AllocPref {
     Infallible,
 }
 
-#[cfg(feature = "zencodec")]
 impl From<zencodec::AllocPreference> for AllocPref {
     fn from(pref: zencodec::AllocPreference) -> Self {
         match pref {
@@ -219,7 +220,6 @@ mod tests {
         assert!(matches!(r.unwrap_err().error(), Error::ResourceLimit(_)));
     }
 
-    #[cfg(feature = "zencodec")]
     #[test]
     fn from_zencodec_alloc_preference_maps_all_modes() {
         assert_eq!(

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -28,7 +28,7 @@ use zencodec::decode::DecodeOutput;
 #[cfg(feature = "encode")]
 use zencodec::encode::EncodeOutput;
 use zencodec::{
-    GainMapPresence, ImageFormat, ImageInfo, ImageSequence, ResourceLimits, Supplements,
+    CodecError, GainMapPresence, ImageFormat, ImageInfo, ImageSequence, ResourceLimits, Supplements,
 };
 use zenpixels::{ChannelType, ColorAuthority, PixelBuffer, PixelDescriptor, PixelSlice};
 use zenpixels_convert::PixelBufferConvertTypedExt as _;
@@ -162,7 +162,10 @@ impl AvifEncoderConfig {
     }
 
     /// Convenience: encode RGB8 pixels with this config.
-    pub fn encode_rgb8(&self, img: imgref::ImgRef<'_, Rgb<u8>>) -> Result<EncodeOutput, At<Error>> {
+    pub fn encode_rgb8(
+        &self,
+        img: imgref::ImgRef<'_, Rgb<u8>>,
+    ) -> Result<EncodeOutput, At<CodecError>> {
         use zencodec::encode::{EncodeJob as _, Encoder as _, EncoderConfig as _};
         self.clone()
             .job()
@@ -174,7 +177,7 @@ impl AvifEncoderConfig {
     pub fn encode_rgba8(
         &self,
         img: imgref::ImgRef<'_, Rgba<u8>>,
-    ) -> Result<EncodeOutput, At<Error>> {
+    ) -> Result<EncodeOutput, At<CodecError>> {
         use zencodec::encode::{EncodeJob as _, Encoder as _, EncoderConfig as _};
         self.clone()
             .job()
@@ -186,7 +189,7 @@ impl AvifEncoderConfig {
     pub fn encode_gray8(
         &self,
         img: imgref::ImgRef<'_, rgb::Gray<u8>>,
-    ) -> Result<EncodeOutput, At<Error>> {
+    ) -> Result<EncodeOutput, At<CodecError>> {
         use zencodec::encode::{EncodeJob as _, Encoder as _, EncoderConfig as _};
         self.clone()
             .job()
@@ -198,7 +201,7 @@ impl AvifEncoderConfig {
     pub fn encode_rgb_f32(
         &self,
         img: imgref::ImgRef<'_, Rgb<f32>>,
-    ) -> Result<EncodeOutput, At<Error>> {
+    ) -> Result<EncodeOutput, At<CodecError>> {
         use zencodec::encode::{EncodeJob as _, Encoder as _, EncoderConfig as _};
         self.clone()
             .job()
@@ -210,7 +213,7 @@ impl AvifEncoderConfig {
     pub fn encode_rgba_f32(
         &self,
         img: imgref::ImgRef<'_, Rgba<f32>>,
-    ) -> Result<EncodeOutput, At<Error>> {
+    ) -> Result<EncodeOutput, At<CodecError>> {
         use zencodec::encode::{EncodeJob as _, Encoder as _, EncoderConfig as _};
         self.clone()
             .job()
@@ -222,7 +225,7 @@ impl AvifEncoderConfig {
     pub fn encode_gray_f32(
         &self,
         img: imgref::ImgRef<'_, rgb::Gray<f32>>,
-    ) -> Result<EncodeOutput, At<Error>> {
+    ) -> Result<EncodeOutput, At<CodecError>> {
         use zencodec::encode::{EncodeJob as _, Encoder as _, EncoderConfig as _};
         self.clone()
             .job()
@@ -394,7 +397,7 @@ fn interp_quality(table: &[(f32, f32)], x: f32) -> f32 {
 
 #[cfg(feature = "encode")]
 impl zencodec::encode::EncoderConfig for AvifEncoderConfig {
-    type Error = At<Error>;
+    type Error = At<CodecError>;
     type Job = AvifEncodeJob;
 
     fn format() -> ImageFormat {
@@ -598,7 +601,7 @@ impl AvifEncodeJob {
 
 #[cfg(feature = "encode")]
 impl zencodec::encode::EncodeJob for AvifEncodeJob {
-    type Error = At<Error>;
+    type Error = At<CodecError>;
     type Enc = AvifEncoder;
     type AnimationFrameEnc = AvifAnimationFrameEncoder;
 
@@ -644,7 +647,7 @@ impl zencodec::encode::EncodeJob for AvifEncodeJob {
         self
     }
 
-    fn encoder(self) -> Result<AvifEncoder, At<Error>> {
+    fn encoder(self) -> Result<AvifEncoder, At<CodecError>> {
         let mut config = self.config.inner.clone();
         // Resolve the color *description* (ICC vs CICP code points) through
         // zencodec's `resolve_color_emit` — the single source of truth for which
@@ -750,7 +753,7 @@ impl zencodec::encode::EncodeJob for AvifEncodeJob {
         self
     }
 
-    fn animation_frame_encoder(self) -> Result<AvifAnimationFrameEncoder, At<Error>> {
+    fn animation_frame_encoder(self) -> Result<AvifAnimationFrameEncoder, At<CodecError>> {
         let mut config = self.config.inner.clone();
         // Resolve color description the same way as the still path (single source
         // of truth): lower the resolved CICP to nclx and carry the resolved ICC.
@@ -1268,10 +1271,12 @@ impl AvifEncoder {
 
 #[cfg(feature = "encode")]
 impl zencodec::encode::Encoder for AvifEncoder {
-    type Error = At<Error>;
+    type Error = At<CodecError>;
 
-    fn reject(op: zencodec::UnsupportedOperation) -> At<Error> {
-        at!(Error::UnsupportedOperation(op))
+    fn reject(op: zencodec::UnsupportedOperation) -> At<CodecError> {
+        // Bare native error exiting the trait boundary: `.into()` routes through
+        // `From<Error> for At<CodecError>`, locating + enveloping in one step.
+        Error::UnsupportedOperation(op).into()
     }
 
     fn encode_srgba8(
@@ -1281,150 +1286,13 @@ impl zencodec::encode::Encoder for AvifEncoder {
         width: u32,
         height: u32,
         stride_pixels: u32,
-    ) -> Result<EncodeOutput, At<Error>> {
-        let w = width as usize;
-        let h = height as usize;
-        let stride = stride_pixels as usize;
-        self.check_limits(w, h, 4)?;
-        let cfg = self.build_config();
-        let stop = self.stop_token();
-
-        if make_opaque {
-            // Strip alpha: RGBA → RGB in-place, then encode RGB
-            let mut rgb = Vec::with_capacity(w * h);
-            for y in 0..h {
-                let row_start = y * stride * 4;
-                let row = &data[row_start..row_start + w * 4];
-                for px in row.chunks_exact(4) {
-                    rgb.push(Rgb {
-                        r: px[0],
-                        g: px[1],
-                        b: px[2],
-                    });
-                }
-            }
-            let img = imgref::ImgVec::new(rgb, w, h);
-            let result = crate::encode_rgb8(img.as_ref(), &cfg, stop)?;
-            self.make_output(result.avif_file)
-        } else {
-            // Zero-copy RGBA path — bytemuck cast the contiguous region
-            if stride == w {
-                let pixel_bytes = &data[..w * h * 4];
-                let rgba: &[Rgba<u8>] = bytemuck::cast_slice(pixel_bytes);
-                let img = imgref::Img::new(rgba, w, h);
-                let result = crate::encode_rgba8(img, &cfg, stop)?;
-                self.make_output(result.avif_file)
-            } else {
-                // Strided: use ImgRef with stride
-                let total_pixels = (h - 1) * stride + w;
-                let pixel_bytes = &data[..total_pixels * 4];
-                let rgba: &[Rgba<u8>] = bytemuck::cast_slice(pixel_bytes);
-                let img = imgref::Img::new_stride(rgba, w, h, stride);
-                let result = crate::encode_rgba8(img, &cfg, stop)?;
-                self.make_output(result.avif_file)
-            }
-        }
+    ) -> Result<EncodeOutput, At<CodecError>> {
+        self.encode_srgba8_inner(data, make_opaque, width, height, stride_pixels)
+            .map_err(zencodec::CodecError::of)
     }
 
-    fn encode(mut self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, At<Error>> {
-        use zenpixels::PixelFormat;
-
-        // Propagate HDR color metadata from pixel descriptor to encoder config
-        let desc = pixels.descriptor();
-        self.apply_descriptor_color(desc);
-
-        // For f32 pixels with HDR transfer (PQ/HLG), convert to u16 and use 16-bit
-        // path to preserve HDR data. The default f32 path uses linear_to_srgb_u8()
-        // which would silently destroy HDR values.
-        let is_hdr_transfer = matches!(
-            desc.transfer,
-            zenpixels::TransferFunction::Pq | zenpixels::TransferFunction::Hlg
-        );
-
-        match desc.pixel_format() {
-            PixelFormat::RgbF32 if is_hdr_transfer => {
-                return self.encode_f32_as_u16_rgb(pixels);
-            }
-            PixelFormat::RgbaF32 if is_hdr_transfer => {
-                return self.encode_f32_as_u16_rgba(pixels);
-            }
-            _ => {}
-        }
-
-        match desc.pixel_format() {
-            PixelFormat::Rgb8 => self.do_encode_rgb8(pixels),
-            PixelFormat::Rgba8 => self.do_encode_rgba8(pixels),
-            PixelFormat::Gray8 => self.do_encode_gray8(pixels),
-            PixelFormat::Rgb16 => self.do_encode_rgb16(pixels),
-            PixelFormat::Rgba16 => self.do_encode_rgba16(pixels),
-            PixelFormat::RgbF32 => self.do_encode_rgb_f32(pixels),
-            PixelFormat::RgbaF32 => self.do_encode_rgba_f32(pixels),
-            PixelFormat::GrayF32 => self.do_encode_gray_f32(pixels),
-            PixelFormat::Bgra8 => {
-                // Swizzle BGRA → RGBA and encode
-                let raw = pixels.contiguous_bytes();
-                let w = pixels.width() as usize;
-                let h = pixels.rows() as usize;
-                self.check_limits(w, h, 4)?;
-                let cfg = self.build_config();
-                let stop = self.stop_token();
-                let rgba: Vec<Rgba<u8>> = raw
-                    .chunks_exact(4)
-                    .map(|c| Rgba {
-                        r: c[2],
-                        g: c[1],
-                        b: c[0],
-                        a: c[3],
-                    })
-                    .collect();
-                let img = imgref::ImgVec::new(rgba, w, h);
-                let result = crate::encode_rgba8(img.as_ref(), &cfg, stop)?;
-                self.make_output(result.avif_file)
-            }
-            PixelFormat::Rgbx8 => {
-                // Byte 3 is padding — strip to 3-channel RGB.
-                let raw = pixels.contiguous_bytes();
-                let w = pixels.width() as usize;
-                let h = pixels.rows() as usize;
-                self.check_limits(w, h, 3)?;
-                let cfg = self.build_config();
-                let stop = self.stop_token();
-                let rgb: Vec<Rgb<u8>> = raw
-                    .chunks_exact(4)
-                    .map(|c| Rgb {
-                        r: c[0],
-                        g: c[1],
-                        b: c[2],
-                    })
-                    .collect();
-                let img = imgref::ImgVec::new(rgb, w, h);
-                let result = crate::encode_rgb8(img.as_ref(), &cfg, stop)?;
-                self.make_output(result.avif_file)
-            }
-            PixelFormat::Bgrx8 => {
-                // BGRA layout with padding byte — swap B↔R and strip to RGB.
-                let raw = pixels.contiguous_bytes();
-                let w = pixels.width() as usize;
-                let h = pixels.rows() as usize;
-                self.check_limits(w, h, 3)?;
-                let cfg = self.build_config();
-                let stop = self.stop_token();
-                let rgb: Vec<Rgb<u8>> = raw
-                    .chunks_exact(4)
-                    .map(|c| Rgb {
-                        r: c[2],
-                        g: c[1],
-                        b: c[0],
-                    })
-                    .collect();
-                let img = imgref::ImgVec::new(rgb, w, h);
-                let result = crate::encode_rgb8(img.as_ref(), &cfg, stop)?;
-                self.make_output(result.avif_file)
-            }
-            _ => Err(at!(Error::UnsupportedOperation(
-                zencodec::UnsupportedOperation::PixelFormat,
-            ))),
-        }
+    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, At<CodecError>> {
+        self.encode_inner(pixels).map_err(zencodec::CodecError::of)
     }
 }
 
@@ -1480,10 +1348,12 @@ impl AvifAnimationFrameEncoder {
 
 #[cfg(feature = "encode")]
 impl zencodec::encode::AnimationFrameEncoder for AvifAnimationFrameEncoder {
-    type Error = At<Error>;
+    type Error = At<CodecError>;
 
-    fn reject(op: zencodec::UnsupportedOperation) -> At<Error> {
-        at!(Error::UnsupportedOperation(op))
+    fn reject(op: zencodec::UnsupportedOperation) -> At<CodecError> {
+        // Bare native error exiting the trait boundary: `.into()` routes through
+        // `From<Error> for At<CodecError>`, locating + enveloping in one step.
+        Error::UnsupportedOperation(op).into()
     }
 
     fn push_frame(
@@ -1491,207 +1361,13 @@ impl zencodec::encode::AnimationFrameEncoder for AvifAnimationFrameEncoder {
         pixels: PixelSlice<'_>,
         duration_ms: u32,
         stop: Option<&dyn Stop>,
-    ) -> Result<(), At<Error>> {
-        // Check cancellation (combine per-call + owned stop)
-        if let Some(s) = stop {
-            s.check().map_err(|e| at!(Error::from(e)))?;
-        }
-        if let Some(ref s) = self.stop {
-            s.check().map_err(|e| at!(Error::from(e)))?;
-        }
-
-        let w = pixels.width();
-        let h = pixels.rows();
-
-        // Validate canvas dimensions match
-        match (self.canvas_width, self.canvas_height) {
-            (Some(cw), Some(ch)) if cw != w || ch != h => {
-                return Err(at!(Error::Encode(format!(
-                    "frame dimensions {}x{} don't match canvas {}x{}",
-                    w, h, cw, ch
-                ))));
-            }
-            (None, None) => {
-                self.canvas_width = Some(w);
-                self.canvas_height = Some(h);
-            }
-            _ => {}
-        }
-
-        // Check resource limits
-        let desc = pixels.descriptor();
-        let bpp = desc.bytes_per_pixel() as u64;
-        self.limits.check_dimensions(w, h).map_err(|_| {
-            at!(Error::ImageTooLarge {
-                width: w,
-                height: h,
-            })
-        })?;
-        self.limits
-            .check_memory(w as u64 * h as u64 * bpp)
-            .map_err(|e| at!(Error::Encode(format!("{e}"))))?;
-
-        // Enforce max_frames limit.
-        self.frame_count += 1;
-        self.limits
-            .check_frames(self.frame_count)
-            .map_err(|e| at!(Error::Encode(format!("{e}"))))?;
-
-        let fmt = desc.pixel_format();
-
-        // Validate consistent pixel format across frames
-        if let Some(expected) = self.pixel_format {
-            if fmt != expected {
-                return Err(at!(Error::Encode(format!(
-                    "pixel format mismatch: first frame was {expected:?}, this frame is {fmt:?}"
-                ))));
-            }
-        } else {
-            self.pixel_format = Some(fmt);
-        }
-
-        let raw = pixels.contiguous_bytes();
-        let wu = w as usize;
-        let hu = h as usize;
-
-        let frame = match fmt {
-            zenpixels::PixelFormat::Rgb8 => {
-                let rgb: Vec<Rgb<u8>> = bytemuck::cast_slice(&raw).to_vec();
-                BufferedFrame::Rgb8 {
-                    pixels: imgref::ImgVec::new(rgb, wu, hu),
-                    duration_ms,
-                }
-            }
-            zenpixels::PixelFormat::Rgba8 => {
-                let rgba: Vec<Rgba<u8>> = bytemuck::cast_slice(&raw).to_vec();
-                BufferedFrame::Rgba8 {
-                    pixels: imgref::ImgVec::new(rgba, wu, hu),
-                    duration_ms,
-                }
-            }
-            zenpixels::PixelFormat::Rgb16 => {
-                let rgb: Vec<Rgb<u16>> = bytemuck::cast_slice(&raw).to_vec();
-                BufferedFrame::Rgb16 {
-                    pixels: imgref::ImgVec::new(rgb, wu, hu),
-                    duration_ms,
-                }
-            }
-            zenpixels::PixelFormat::Rgba16 => {
-                let rgba: Vec<Rgba<u16>> = bytemuck::cast_slice(&raw).to_vec();
-                BufferedFrame::Rgba16 {
-                    pixels: imgref::ImgVec::new(rgba, wu, hu),
-                    duration_ms,
-                }
-            }
-            _ => {
-                return Err(at!(Error::UnsupportedOperation(
-                    zencodec::UnsupportedOperation::PixelFormat,
-                )));
-            }
-        };
-
-        self.frames.push(frame);
-        Ok(())
+    ) -> Result<(), At<CodecError>> {
+        self.push_frame_inner(pixels, duration_ms, stop)
+            .map_err(zencodec::CodecError::of)
     }
 
-    fn finish(self, stop: Option<&dyn Stop>) -> Result<EncodeOutput, At<Error>> {
-        if let Some(s) = stop {
-            s.check().map_err(|e| at!(Error::from(e)))?;
-        }
-        if let Some(ref s) = self.stop {
-            s.check().map_err(|e| at!(Error::from(e)))?;
-        }
-
-        if self.frames.is_empty() {
-            return Err(at!(Error::Encode("no frames to encode".into())));
-        }
-
-        let stop_token = self.stop_token();
-
-        let avif_file = match self.frames[0] {
-            BufferedFrame::Rgb8 { .. } => {
-                let anim_frames: Vec<crate::AnimationFrame> = self
-                    .frames
-                    .into_iter()
-                    .map(|f| match f {
-                        BufferedFrame::Rgb8 {
-                            pixels,
-                            duration_ms,
-                        } => crate::AnimationFrame {
-                            pixels,
-                            duration_ms,
-                        },
-                        _ => unreachable!(),
-                    })
-                    .collect();
-                let result =
-                    crate::encode_animation_rgb8(&anim_frames, &self.config, stop_token.clone())?;
-                result.avif_file
-            }
-            BufferedFrame::Rgba8 { .. } => {
-                let anim_frames: Vec<crate::AnimationFrameRgba> = self
-                    .frames
-                    .into_iter()
-                    .map(|f| match f {
-                        BufferedFrame::Rgba8 {
-                            pixels,
-                            duration_ms,
-                        } => crate::AnimationFrameRgba {
-                            pixels,
-                            duration_ms,
-                        },
-                        _ => unreachable!(),
-                    })
-                    .collect();
-                let result =
-                    crate::encode_animation_rgba8(&anim_frames, &self.config, stop_token.clone())?;
-                result.avif_file
-            }
-            BufferedFrame::Rgb16 { .. } => {
-                let anim_frames: Vec<crate::AnimationFrame16> = self
-                    .frames
-                    .into_iter()
-                    .map(|f| match f {
-                        BufferedFrame::Rgb16 {
-                            pixels,
-                            duration_ms,
-                        } => crate::AnimationFrame16 {
-                            pixels,
-                            duration_ms,
-                        },
-                        _ => unreachable!(),
-                    })
-                    .collect();
-                let result =
-                    crate::encode_animation_rgb16(&anim_frames, &self.config, stop_token.clone())?;
-                result.avif_file
-            }
-            BufferedFrame::Rgba16 { .. } => {
-                let anim_frames: Vec<crate::AnimationFrameRgba16> = self
-                    .frames
-                    .into_iter()
-                    .map(|f| match f {
-                        BufferedFrame::Rgba16 {
-                            pixels,
-                            duration_ms,
-                        } => crate::AnimationFrameRgba16 {
-                            pixels,
-                            duration_ms,
-                        },
-                        _ => unreachable!(),
-                    })
-                    .collect();
-                let result =
-                    crate::encode_animation_rgba16(&anim_frames, &self.config, stop_token.clone())?;
-                result.avif_file
-            }
-        };
-
-        self.limits
-            .check_output_size(avif_file.len() as u64)
-            .map_err(|e| at!(Error::Encode(format!("{e}"))))?;
-
-        Ok(EncodeOutput::new(avif_file, ImageFormat::Avif))
+    fn finish(self, stop: Option<&dyn Stop>) -> Result<EncodeOutput, At<CodecError>> {
+        self.finish_inner(stop).map_err(zencodec::CodecError::of)
     }
 }
 
@@ -1801,7 +1477,7 @@ impl AvifDecoderConfig {
     }
 
     /// Convenience: decode image with this config.
-    pub fn decode(&self, data: &[u8]) -> Result<DecodeOutput, At<Error>> {
+    pub fn decode(&self, data: &[u8]) -> Result<DecodeOutput, At<CodecError>> {
         use zencodec::decode::{Decode as _, DecodeJob as _, DecoderConfig as _};
         self.clone()
             .job()
@@ -1810,13 +1486,13 @@ impl AvifDecoderConfig {
     }
 
     /// Convenience: probe image header with this config.
-    pub fn probe_header(&self, data: &[u8]) -> Result<ImageInfo, At<Error>> {
+    pub fn probe_header(&self, data: &[u8]) -> Result<ImageInfo, At<CodecError>> {
         use zencodec::decode::{DecodeJob as _, DecoderConfig as _};
         self.clone().job().probe(data)
     }
 
     /// Convenience: probe full image metadata (may be expensive).
-    pub fn probe_full(&self, data: &[u8]) -> Result<ImageInfo, At<Error>> {
+    pub fn probe_full(&self, data: &[u8]) -> Result<ImageInfo, At<CodecError>> {
         use zencodec::decode::{DecodeJob as _, DecoderConfig as _};
         self.clone().job().probe_full(data)
     }
@@ -1826,7 +1502,7 @@ impl AvifDecoderConfig {
         &self,
         data: &[u8],
         mut dst: imgref::ImgRefMut<'_, Rgb<u8>>,
-    ) -> Result<ImageInfo, At<Error>> {
+    ) -> Result<ImageInfo, At<CodecError>> {
         let output = self.decode(data)?;
         let info = output.info().clone();
         map_rgb8_rows(&output.into_buffer(), &mut dst, |s, d| {
@@ -1840,7 +1516,7 @@ impl AvifDecoderConfig {
         &self,
         data: &[u8],
         mut dst: imgref::ImgRefMut<'_, Rgba<u8>>,
-    ) -> Result<ImageInfo, At<Error>> {
+    ) -> Result<ImageInfo, At<CodecError>> {
         let output = self.decode(data)?;
         let info = output.info().clone();
         map_rgba8_rows(&output.into_buffer(), &mut dst, |s, d| {
@@ -1854,7 +1530,7 @@ impl AvifDecoderConfig {
         &self,
         data: &[u8],
         mut dst: imgref::ImgRefMut<'_, Rgb<f32>>,
-    ) -> Result<ImageInfo, At<Error>> {
+    ) -> Result<ImageInfo, At<CodecError>> {
         use linear_srgb::default::srgb_u8_to_linear;
         let output = self.decode(data)?;
         let info = output.info().clone();
@@ -1875,7 +1551,7 @@ impl AvifDecoderConfig {
         &self,
         data: &[u8],
         mut dst: imgref::ImgRefMut<'_, Rgba<f32>>,
-    ) -> Result<ImageInfo, At<Error>> {
+    ) -> Result<ImageInfo, At<CodecError>> {
         use linear_srgb::default::srgb_u8_to_linear;
         let output = self.decode(data)?;
         let info = output.info().clone();
@@ -1897,7 +1573,7 @@ impl AvifDecoderConfig {
         &self,
         data: &[u8],
         mut dst: imgref::ImgRefMut<'_, rgb::Gray<f32>>,
-    ) -> Result<ImageInfo, At<Error>> {
+    ) -> Result<ImageInfo, At<CodecError>> {
         use linear_srgb::default::srgb_u8_to_linear;
         let output = self.decode(data)?;
         let info = output.info().clone();
@@ -2002,7 +1678,7 @@ static AVIF_DECODE_CAPABILITIES: zencodec::decode::DecodeCapabilities =
         .with_threads_supported_range(1, 256);
 
 impl zencodec::decode::DecoderConfig for AvifDecoderConfig {
-    type Error = At<Error>;
+    type Error = At<CodecError>;
     type Job<'a> = AvifDecodeJob;
 
     fn formats() -> &'static [ImageFormat] {
@@ -2180,7 +1856,7 @@ impl AvifDecodeJob {
 }
 
 impl<'a> zencodec::decode::DecodeJob<'a> for AvifDecodeJob {
-    type Error = At<Error>;
+    type Error = At<CodecError>;
     type Dec = AvifDecoder<'a>;
     type StreamDec = AvifStreamingDecoder;
     type AnimationFrameDec = AvifAnimationFrameDecoder;
@@ -2224,68 +1900,13 @@ impl<'a> zencodec::decode::DecodeJob<'a> for AvifDecodeJob {
         self
     }
 
-    fn probe(&self, data: &[u8]) -> Result<ImageInfo, At<Error>> {
-        let decoder = crate::ManagedAvifDecoder::new(data, &self.config.inner)?;
-        let native_info = decoder.probe_info()?;
-        // `convert_native_info` reports the Preserve view (stored dims +
-        // intrinsic tag); rewrite to display dims + Identity on the bake path.
-        let mut info = apply_reported_orientation(
-            convert_native_info(&native_info),
-            &native_info,
-            self.orientation,
-        );
-        // Detect animation from the container's track structure.
-        if let Some(anim) = decoder.animation_info() {
-            info = info.with_sequence(ImageSequence::Animation {
-                frame_count: Some(anim.frame_count as u32),
-                loop_count: Some(anim.loop_count),
-                random_access: true,
-            });
-        }
-        if let Ok(probe) = crate::detect::probe(data) {
-            info = info.with_source_encoding_details(probe);
-        }
-        if let Some(ref policy) = self.policy {
-            apply_decode_policy(&mut info, policy);
-        }
-        Ok(info)
+    fn probe(&self, data: &[u8]) -> Result<ImageInfo, At<CodecError>> {
+        self.probe_inner(data).map_err(zencodec::CodecError::of)
     }
 
-    fn output_info(&self, data: &[u8]) -> Result<zencodec::decode::OutputInfo, At<Error>> {
-        let decoder = crate::ManagedAvifDecoder::new(data, &self.config.inner)?;
-        let native_info = decoder.probe_info()?;
-        let mut desc = if native_info.bit_depth > 8 {
-            if native_info.has_alpha {
-                PixelDescriptor::RGBA16_SRGB
-            } else {
-                PixelDescriptor::RGB16_SRGB
-            }
-        } else if native_info.has_alpha {
-            PixelDescriptor::RGBA8_SRGB
-        } else {
-            PixelDescriptor::RGB8_SRGB
-        };
-        // Override TF and primaries from CICP if available.
-        if let Some(tf) =
-            zenpixels::TransferFunction::from_cicp(native_info.transfer_characteristics.0)
-        {
-            desc = desc.with_transfer(tf);
-        }
-        if let Some(p) = zenpixels::ColorPrimaries::from_cicp(native_info.color_primaries.0) {
-            desc = desc.with_primaries(p);
-        }
-        // Report the post-orientation output dims + what the decoder bakes:
-        // `Correct` bakes the intrinsic orientation (output = display dims,
-        // `orientation_applied` = intrinsic); `Preserve` bakes nothing
-        // (output = stored dims, `orientation_applied` = Identity, caller orients).
-        let (w, h, _) = reported_dims_and_orientation(&native_info, self.orientation);
-        let orientation_applied = if will_auto_orient(self.orientation) {
-            intrinsic_orientation(&native_info)
-        } else {
-            zencodec::Orientation::Identity
-        };
-        Ok(zencodec::decode::OutputInfo::full_decode(w, h, desc)
-            .with_orientation_applied(orientation_applied))
+    fn output_info(&self, data: &[u8]) -> Result<zencodec::decode::OutputInfo, At<CodecError>> {
+        self.output_info_inner(data)
+            .map_err(zencodec::CodecError::of)
     }
 
     fn push_decoder(
@@ -2293,349 +1914,52 @@ impl<'a> zencodec::decode::DecodeJob<'a> for AvifDecodeJob {
         data: Cow<'a, [u8]>,
         sink: &mut dyn zencodec::decode::DecodeRowSink,
         preferred: &[PixelDescriptor],
-    ) -> Result<zencodec::decode::OutputInfo, At<Error>> {
+    ) -> Result<zencodec::decode::OutputInfo, At<CodecError>> {
         // Bake path: orientation isn't row-local, so a true row-streamed sink
         // would emit pixels in stored orientation. Route through a full decode
         // (which bakes the buffer upright and reports display dims) and copy the
         // baked rows to the sink. `Preserve` (default) keeps the native, low-
         // memory streaming sink unchanged.
+        //
+        // `copy_decode_to_sink` is generic over `Self`, so it already returns
+        // `Self::Error` (= `At<CodecError>`); the sink-error wrap bridges a bare
+        // native `Error` into the envelope via `.into()`. The non-bake path keeps
+        // its verbatim `At<Error>` body in `push_decoder_inner` and is re-wrapped
+        // once at this boundary.
         if will_auto_orient(self.orientation) {
             return zencodec::helpers::copy_decode_to_sink(self, data, sink, preferred, |e| {
-                at!(Error::Encode(e.to_string()))
+                Error::Encode(e.to_string()).into()
             });
         }
-
-        self.check_input_size(&data)?;
-        let cfg = self.effective_config();
-        let stop: &dyn Stop = match &self.stop {
-            Some(s) => s,
-            None => &enough::Unstoppable,
-        };
-        let mut decoder = crate::ManagedAvifDecoder::new(&data, &cfg)?;
-        let probe_info = decoder.probe_info()?;
-        self.check_decode_limits(&probe_info)?;
-        let native_info = decoder.decode_to_sink(stop, sink)?;
-
-        let desc = if native_info.bit_depth > 8 {
-            if native_info.has_alpha {
-                PixelDescriptor::RGBA16_SRGB
-            } else {
-                PixelDescriptor::RGB16_SRGB
-            }
-        } else if native_info.has_alpha {
-            PixelDescriptor::RGBA8_SRGB
-        } else {
-            PixelDescriptor::RGB8_SRGB
-        };
-        Ok(zencodec::decode::OutputInfo::full_decode(
-            native_info.width,
-            native_info.height,
-            desc,
-        ))
+        self.push_decoder_inner(data, sink)
+            .map_err(zencodec::CodecError::of)
     }
 
     fn decoder(
         self,
         data: Cow<'a, [u8]>,
         preferred: &[PixelDescriptor],
-    ) -> Result<AvifDecoder<'a>, At<Error>> {
-        self.check_input_size(&data)?;
-        let cfg = self.effective_config();
-        Ok(AvifDecoder {
-            config: cfg,
-            stop: self.stop,
-            data,
-            preferred: preferred.to_vec(),
-            limits: self.limits,
-            policy: self.policy,
-            extract_gain_map: self.extract_gain_map,
-            gain_map_render: self.gain_map_render,
-            orientation: self.orientation,
-        })
+    ) -> Result<AvifDecoder<'a>, At<CodecError>> {
+        self.decoder_inner(data, preferred)
+            .map_err(zencodec::CodecError::of)
     }
 
     fn streaming_decoder(
-        mut self,
+        self,
         data: Cow<'a, [u8]>,
         preferred: &[PixelDescriptor],
-    ) -> Result<AvifStreamingDecoder, At<Error>> {
-        self.check_input_size(&data)?;
-        let cfg = self.effective_config();
-        let stop_token = self
-            .stop
-            .take()
-            .unwrap_or_else(|| zencodec::StopToken::new(enough::Unstoppable));
-
-        let mut decoder = crate::ManagedAvifDecoder::new(&data, &cfg)?;
-        let native_info = decoder.probe_info()?;
-        self.check_decode_limits(&native_info)?;
-
-        // Native grayscale opt-in (zenavif#5) — mirrors the buffered
-        // decode: alpha-free monochrome, not reconstructing, not a grid
-        // (the grid branch below stitches RGB tiles), gray negotiated.
-        // The monochrome strip path runs through full conversion +
-        // `StripConverter::new_from_pixels`, which carries the gray
-        // descriptor into the emitted strips.
-        let mono_source = native_info.monochrome && !native_info.has_alpha;
-        let reconstructing = matches!(
-            self.gain_map_render,
-            zencodec::GainMapRender::ReconstructHdr { .. }
-        ) && native_info.gain_map.is_some();
-        if mono_source
-            && !reconstructing
-            && !decoder.is_grid()
-            && icc_allows_native_gray(&native_info)
-            && wants_gray_output(preferred)
-        {
-            decoder.set_native_gray(true);
-        }
-
-        // ReconstructHdr path: gain-map application is whole-image (the
-        // map is sampled at an image-to-map scale ratio), so decode the
-        // full buffer, reconstruct, then emit fixed-height strips —
-        // same shape as the orientation-bake path below. Files without
-        // a gain map fall through to honest SDR streaming.
-        if let zencodec::GainMapRender::ReconstructHdr { target_headroom } = self.gain_map_render
-            && native_info.gain_map.is_some()
-        {
-            let (pixels, native_info) = decoder.decode_full(&stop_token)?;
-            let pixels = set_cicp_on_pixels(pixels, &native_info);
-            let pixels = attach_source_color_context(pixels, &native_info);
-            let (hdr, (max_cll, max_fall)) =
-                reconstruct_hdr_pixels(pixels, &native_info, target_headroom, &stop_token)?;
-            let (baked, _orientation, w, h) = bake_orientation(hdr, &native_info, self.orientation);
-            let strip_descriptor = baked.descriptor();
-            let mut info = apply_reported_orientation(
-                convert_native_info(&native_info),
-                &native_info,
-                self.orientation,
-            );
-            // Measured envelope of the reconstructed pixels (zencodec
-            // contract: MaxCLL/MaxFALL are measured; mastering display
-            // passes through unchanged).
-            info =
-                info.with_content_light_level(zencodec::ContentLightLevel::new(max_cll, max_fall));
-            let strip_height = 64u32.min(h.max(1));
-            return Ok(AvifStreamingDecoder {
-                info,
-                y_offset: 0,
-                output_width: w,
-                output_height: h,
-                decoder: None,
-                stop: stop_token,
-                grid_rows: 0,
-                grid_cols: 0,
-                current_grid_row: 0,
-                strip_descriptor,
-                strip_buffer: None,
-                strip_converter: None,
-                strip_height,
-                strip_color_context: baked.color_context().cloned(),
-                baked: Some(baked),
-            });
-        }
-
-        // Bake path: orientation is not strip-local (transposes need the whole
-        // image), so decode + bake the full buffer once and emit it in
-        // fixed-height strips. Mirrors `Decode::decode`'s buffer pipeline. The
-        // preserve path (default) falls through to the low-memory grid / strip-
-        // converter streaming below, unchanged.
-        if will_auto_orient(self.orientation) {
-            let (pixels, native_info) = decoder.decode_full(&stop_token)?;
-            let pixels = set_cicp_on_pixels(pixels, &native_info);
-            let pixels = attach_source_color_context(pixels, &native_info);
-            let pixels = negotiate_format(
-                pixels,
-                preferred,
-                native_info.monochrome && !native_info.has_alpha,
-            );
-            let (baked, _orientation, w, h) =
-                bake_orientation(pixels, &native_info, self.orientation);
-            let strip_descriptor = baked.descriptor();
-            let info = apply_reported_orientation(
-                convert_native_info(&native_info),
-                &native_info,
-                self.orientation,
-            );
-            // Emit in cache-friendly fixed-height strips (or the whole image if
-            // it's short). The baked buffer is contiguous, so a strip is just a
-            // row-range view re-copied into a small buffer.
-            let strip_height = 64u32.min(h.max(1));
-            return Ok(AvifStreamingDecoder {
-                info,
-                y_offset: 0,
-                output_width: w,
-                output_height: h,
-                decoder: None,
-                stop: stop_token,
-                grid_rows: 0,
-                grid_cols: 0,
-                current_grid_row: 0,
-                strip_descriptor,
-                strip_buffer: None,
-                strip_converter: None,
-                strip_height,
-                strip_color_context: baked.color_context().cloned(),
-                baked: Some(baked),
-            });
-        }
-
-        let info = convert_native_info(&native_info);
-
-        if decoder.is_grid() {
-            let grid = decoder
-                .grid_config()
-                .ok_or_else(|| at!(Error::Unsupported("grid_config missing after is_grid()")))?;
-            let output_width = grid.output_width;
-            let output_height = grid.output_height;
-
-            let base_desc = if native_info.bit_depth > 8 {
-                if native_info.has_alpha {
-                    PixelDescriptor::RGBA16_SRGB
-                } else {
-                    PixelDescriptor::RGB16_SRGB
-                }
-            } else if native_info.has_alpha {
-                PixelDescriptor::RGBA8_SRGB
-            } else {
-                PixelDescriptor::RGB8_SRGB
-            };
-
-            // Apply CICP metadata to descriptor. No format negotiation for
-            // the grid path — tiles produce native format and we stitch raw bytes.
-            let mut strip_descriptor = base_desc;
-            if let Some(tf) =
-                zenpixels::TransferFunction::from_cicp(native_info.transfer_characteristics.0)
-            {
-                strip_descriptor = strip_descriptor.with_transfer(tf);
-            }
-            if let Some(p) = zenpixels::ColorPrimaries::from_cicp(native_info.color_primaries.0) {
-                strip_descriptor = strip_descriptor.with_primaries(p);
-            }
-
-            return Ok(AvifStreamingDecoder {
-                info,
-                y_offset: 0,
-                output_width,
-                output_height,
-                decoder: Some(decoder),
-                stop: stop_token,
-                grid_rows: grid.rows as u32,
-                grid_cols: grid.columns as u32,
-                current_grid_row: 0,
-                strip_descriptor,
-                strip_buffer: None,
-                strip_converter: None,
-                strip_height: 0,
-                strip_color_context: color_context_for_layout(
-                    &native_source_color(&native_info),
-                    strip_descriptor.layout(),
-                ),
-                baked: None,
-            });
-        }
-
-        // Non-grid: decode YUV, set up strip converter for on-demand conversion.
-        // Use the frame-era info the converter returns (not the probe-era
-        // one): the buffered path attaches its context from decode_full's
-        // info, and strips must describe pixels identically.
-        let (converter, frame_native) = decoder.decode_to_strip_converter(&stop_token)?;
-        let desc = converter.descriptor();
-        let w = converter.display_width() as u32;
-        let h = converter.display_height() as u32;
-        let strip_h = converter.optimal_strip_height() as u32;
-
-        Ok(AvifStreamingDecoder {
-            info,
-            y_offset: 0,
-            output_width: w,
-            output_height: h,
-            decoder: None,
-            stop: stop_token,
-            grid_rows: 0,
-            grid_cols: 0,
-            current_grid_row: 0,
-            strip_descriptor: desc,
-            strip_buffer: None,
-            strip_converter: Some(converter),
-            strip_height: strip_h,
-            strip_color_context: color_context_for_layout(
-                &native_source_color(&frame_native),
-                desc.layout(),
-            ),
-            baked: None,
-        })
+    ) -> Result<AvifStreamingDecoder, At<CodecError>> {
+        self.streaming_decoder_inner(data, preferred)
+            .map_err(zencodec::CodecError::of)
     }
 
     fn animation_frame_decoder(
         self,
         data: Cow<'a, [u8]>,
         preferred: &[PixelDescriptor],
-    ) -> Result<AvifAnimationFrameDecoder, At<Error>> {
-        // Reject animation when policy disallows it.
-        if let Some(ref policy) = self.policy
-            && !policy.resolve_animation(true)
-        {
-            return Err(at!(Error::UnsupportedOperation(
-                zencodec::UnsupportedOperation::AnimationDecode,
-            )));
-        }
-        self.check_input_size(&data)?;
-        let cfg = self.effective_config();
-
-        // Probe metadata before creating animation decoder (both parse the container,
-        // but ManagedAvifDecoder gives us the native ImageInfo for conversion).
-        let probe_dec = crate::ManagedAvifDecoder::new(&data, &cfg)?;
-        let native_info = probe_dec.probe_info()?;
-        self.check_decode_limits(&native_info)?;
-        drop(probe_dec);
-
-        let anim_dec = crate::AnimationDecoder::new(&data, &cfg)?;
-        let anim_info = anim_dec.info().clone();
-
-        // `convert_native_info` reports the Preserve view (stored dims +
-        // intrinsic tag); the bake path rewrites the canvas to display dims +
-        // Identity, matching the per-frame buffers `render_next_frame` bakes.
-        let mut base_info = apply_reported_orientation(
-            convert_native_info(&native_info),
-            &native_info,
-            self.orientation,
-        )
-        .with_sequence(ImageSequence::Animation {
-            frame_count: Some(anim_info.frame_count as u32),
-            loop_count: Some(anim_info.loop_count),
-            random_access: true,
-        });
-        // Attach source encoding details to the shared animation ImageInfo.
-        if let Ok(probe) = crate::detect::probe(&data) {
-            base_info = base_info.with_source_encoding_details(probe);
-        }
-        if let Some(ref policy) = self.policy {
-            apply_decode_policy(&mut base_info, policy);
-        }
-
-        // Resolve the orientation to bake into each frame: the intrinsic
-        // transform on the bake path, `Identity` (no-op) on the preserve path.
-        let bake_to = if will_auto_orient(self.orientation) {
-            intrinsic_orientation(&native_info)
-        } else {
-            zencodec::Orientation::Identity
-        };
-
-        Ok(AvifAnimationFrameDecoder {
-            anim_decoder: anim_dec,
-            index: 0,
-            frames_decoded: 0,
-            start_frame_index: self.start_frame_index,
-            info: Arc::new(base_info),
-            total_frames: anim_info.frame_count as u32,
-            loop_count: anim_info.loop_count,
-            preferred: preferred.to_vec(),
-            current_frame: None,
-            limits: self.limits,
-            accumulated_ms: 0,
-            bake_to,
-        })
+    ) -> Result<AvifAnimationFrameDecoder, At<CodecError>> {
+        self.animation_frame_decoder_inner(data, preferred)
+            .map_err(zencodec::CodecError::of)
     }
 }
 
@@ -3352,9 +2676,952 @@ pub struct AvifDecoder<'a> {
 }
 
 impl zencodec::decode::Decode for AvifDecoder<'_> {
-    type Error = At<Error>;
+    type Error = At<CodecError>;
 
-    fn decode(self) -> Result<DecodeOutput, At<Error>> {
+    fn decode(self) -> Result<DecodeOutput, At<CodecError>> {
+        self.decode_inner().map_err(zencodec::CodecError::of)
+    }
+}
+
+/// Streaming AVIF decoder with real tile-row streaming for grid images.
+///
+/// For grid (tiled) images, each [`next_batch`](zencodec::decode::StreamingDecode::next_batch)
+/// call decodes one tile-row of AV1 tiles, color-converts them, and stitches
+/// them into a strip. Peak memory is proportional to one tile-row instead of
+/// the full image.
+///
+/// For non-grid 8-bit color images, the decoded YUV frame is held in memory
+/// and converted strip-by-strip on demand. This eliminates the full RGB
+/// allocation and keeps the working set in L2 cache.
+///
+/// For non-grid 16-bit or monochrome images, falls back to full-frame
+/// conversion and emits fixed-height strips.
+pub struct AvifStreamingDecoder {
+    info: ImageInfo,
+    y_offset: u32,
+    output_width: u32,
+    output_height: u32,
+    /// Grid path: managed decoder for tile-row streaming.
+    decoder: Option<crate::ManagedAvifDecoder>,
+    /// Stop token for cancellable grid decoding.
+    stop: zencodec::StopToken,
+    grid_rows: u32,
+    grid_cols: u32,
+    current_grid_row: u32,
+    /// Pixel descriptor with CICP metadata for strip buffers.
+    strip_descriptor: PixelDescriptor,
+    /// Reusable strip buffer for the current tile-row or strip conversion.
+    strip_buffer: Option<PixelBuffer>,
+    /// Non-grid strip conversion: holds decoded YUV frames, converts on demand.
+    strip_converter: Option<crate::strip_convert::StripConverter>,
+    /// Optimal strip height for the strip converter path.
+    strip_height: u32,
+    /// Class-gated color context applied to every emitted strip: the
+    /// scratch `strip_buffer` is rebuilt per batch without one, so the
+    /// context is re-attached at emission. `None` when the source
+    /// carries no color signaling (or the HDR/bake source buffer had
+    /// none).
+    strip_color_context: Option<Arc<zenpixels::ColorContext>>,
+    /// Bake path (`OrientationHint::bakes()`): the fully-decoded, orientation-
+    /// baked buffer. Orientation is not strip-local (transposes need the whole
+    /// image), so the bake path materializes upright once and emits it in
+    /// fixed-height strips. `None` on the preserve path (the default), where the
+    /// grid / strip-converter fields drive low-memory streaming unchanged.
+    baked: Option<PixelBuffer>,
+}
+
+impl AvifStreamingDecoder {
+    /// Stitch decoded tiles horizontally into `self.strip_buffer`.
+    fn stitch_tiles(&mut self, tiles: &[PixelBuffer], strip_h: u32) {
+        let bpp = self.strip_descriptor.bytes_per_pixel();
+        let mut strip = PixelBuffer::new(self.output_width, strip_h, self.strip_descriptor);
+        {
+            let mut sm = strip.as_slice_mut();
+            for py in 0..strip_h {
+                let dst_row = sm.row_mut(py);
+                let mut x_offset = 0usize;
+                for tile in tiles {
+                    let tile_w = tile.width() as usize;
+                    let actual_w =
+                        tile_w.min((self.output_width as usize).saturating_sub(x_offset));
+                    if actual_w == 0 {
+                        continue;
+                    }
+                    let tile_slice = tile.as_slice();
+                    let src = tile_slice.row(py);
+                    let copy_bytes = actual_w * bpp;
+                    let dst_start = x_offset * bpp;
+                    dst_row[dst_start..dst_start + copy_bytes].copy_from_slice(&src[..copy_bytes]);
+                    x_offset += tile_w;
+                }
+            }
+        }
+        self.strip_buffer = Some(strip);
+    }
+}
+
+impl zencodec::decode::StreamingDecode for AvifStreamingDecoder {
+    type Error = At<CodecError>;
+
+    fn next_batch(&mut self) -> Result<Option<(u32, PixelSlice<'_>)>, At<CodecError>> {
+        self.next_batch_inner().map_err(zencodec::CodecError::of)
+    }
+
+    fn info(&self) -> &ImageInfo {
+        &self.info
+    }
+}
+
+// ── Frame Decoder ───────────────────────────────────────────────────────────
+
+/// Animation AVIF full-frame decoder.
+///
+/// Lazily decodes frames on demand. The `AnimationFrameDecoder` trait doesn't pass
+/// a stop token per-call, so per-frame cancellation is not available
+/// through this interface (use the native `AnimationDecoder` API for that).
+pub struct AvifAnimationFrameDecoder {
+    anim_decoder: crate::AnimationDecoder,
+    index: usize,
+    /// Number of frames decoded so far (including skipped ones).
+    frames_decoded: u32,
+    /// Skip frames before this index. Frames are still decoded to maintain
+    /// correct compositing state, but not yielded to the caller.
+    start_frame_index: u32,
+    info: Arc<ImageInfo>,
+    total_frames: u32,
+    /// Animation loop count (0 = infinite, n = play n times).
+    loop_count: u32,
+    preferred: Vec<PixelDescriptor>,
+    /// Holds the current frame's pixels so `render_next_frame` can return
+    /// a borrowing `AnimationFrame<'_>`.
+    current_frame: Option<PixelBuffer>,
+    /// Resource limits for frame count and animation duration enforcement.
+    limits: ResourceLimits,
+    /// Accumulated animation duration in milliseconds across all decoded frames.
+    accumulated_ms: u64,
+    /// Orientation to bake into every frame: the intrinsic `irot`/`imir`
+    /// transform on the bake path (`OrientationHint::bakes()`), or `Identity`
+    /// (no-op) on the preserve path (the default). Applied after format
+    /// negotiation, before the frame is yielded.
+    bake_to: zencodec::Orientation,
+}
+
+impl zencodec::decode::AnimationFrameDecoder for AvifAnimationFrameDecoder {
+    type Error = At<CodecError>;
+
+    fn wrap_sink_error(err: zencodec::decode::SinkError) -> Self::Error {
+        // Bare native error -> envelope via the `From<Error> for At<CodecError>` bridge.
+        Error::ResourceLimit(err.to_string()).into()
+    }
+
+    fn info(&self) -> &ImageInfo {
+        &self.info
+    }
+
+    fn frame_count(&self) -> Option<u32> {
+        Some(self.total_frames)
+    }
+
+    fn loop_count(&self) -> Option<u32> {
+        Some(self.loop_count)
+    }
+
+    fn render_next_frame(
+        &mut self,
+        stop: Option<&dyn zencodec::enough::Stop>,
+    ) -> Result<Option<AnimationFrame<'_>>, At<CodecError>> {
+        self.render_next_frame_inner(stop)
+            .map_err(zencodec::CodecError::of)
+    }
+
+    fn render_next_frame_to_sink(
+        &mut self,
+        stop: Option<&dyn zencodec::enough::Stop>,
+        sink: &mut dyn zencodec::decode::DecodeRowSink,
+    ) -> Result<Option<zencodec::decode::OutputInfo>, Self::Error> {
+        zencodec::helpers::copy_frame_to_sink(self, stop, sink)
+    }
+}
+
+// ── Pattern B envelope: the original At<Error> method bodies, moved to private
+// inherent `*_inner` helpers. Each zencodec trait method above is now a thin
+// `self.*_inner(..).map_err(zencodec::CodecError::of)` boundary that re-wraps the
+// located native error into the shared `At<CodecError>` envelope (Pattern B),
+// preserving the whereat trace. The inherent helpers keep the verbatim logic.
+
+#[cfg(feature = "encode")]
+impl AvifEncoder {
+    fn encode_srgba8_inner(
+        self,
+        data: &mut [u8],
+        make_opaque: bool,
+        width: u32,
+        height: u32,
+        stride_pixels: u32,
+    ) -> Result<EncodeOutput, At<Error>> {
+        let w = width as usize;
+        let h = height as usize;
+        let stride = stride_pixels as usize;
+        self.check_limits(w, h, 4)?;
+        let cfg = self.build_config();
+        let stop = self.stop_token();
+
+        if make_opaque {
+            // Strip alpha: RGBA → RGB in-place, then encode RGB
+            let mut rgb = Vec::with_capacity(w * h);
+            for y in 0..h {
+                let row_start = y * stride * 4;
+                let row = &data[row_start..row_start + w * 4];
+                for px in row.chunks_exact(4) {
+                    rgb.push(Rgb {
+                        r: px[0],
+                        g: px[1],
+                        b: px[2],
+                    });
+                }
+            }
+            let img = imgref::ImgVec::new(rgb, w, h);
+            let result = crate::encode_rgb8(img.as_ref(), &cfg, stop)?;
+            self.make_output(result.avif_file)
+        } else {
+            // Zero-copy RGBA path — bytemuck cast the contiguous region
+            if stride == w {
+                let pixel_bytes = &data[..w * h * 4];
+                let rgba: &[Rgba<u8>] = bytemuck::cast_slice(pixel_bytes);
+                let img = imgref::Img::new(rgba, w, h);
+                let result = crate::encode_rgba8(img, &cfg, stop)?;
+                self.make_output(result.avif_file)
+            } else {
+                // Strided: use ImgRef with stride
+                let total_pixels = (h - 1) * stride + w;
+                let pixel_bytes = &data[..total_pixels * 4];
+                let rgba: &[Rgba<u8>] = bytemuck::cast_slice(pixel_bytes);
+                let img = imgref::Img::new_stride(rgba, w, h, stride);
+                let result = crate::encode_rgba8(img, &cfg, stop)?;
+                self.make_output(result.avif_file)
+            }
+        }
+    }
+
+    fn encode_inner(mut self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, At<Error>> {
+        use zenpixels::PixelFormat;
+
+        // Propagate HDR color metadata from pixel descriptor to encoder config
+        let desc = pixels.descriptor();
+        self.apply_descriptor_color(desc);
+
+        // For f32 pixels with HDR transfer (PQ/HLG), convert to u16 and use 16-bit
+        // path to preserve HDR data. The default f32 path uses linear_to_srgb_u8()
+        // which would silently destroy HDR values.
+        let is_hdr_transfer = matches!(
+            desc.transfer,
+            zenpixels::TransferFunction::Pq | zenpixels::TransferFunction::Hlg
+        );
+
+        match desc.pixel_format() {
+            PixelFormat::RgbF32 if is_hdr_transfer => {
+                return self.encode_f32_as_u16_rgb(pixels);
+            }
+            PixelFormat::RgbaF32 if is_hdr_transfer => {
+                return self.encode_f32_as_u16_rgba(pixels);
+            }
+            _ => {}
+        }
+
+        match desc.pixel_format() {
+            PixelFormat::Rgb8 => self.do_encode_rgb8(pixels),
+            PixelFormat::Rgba8 => self.do_encode_rgba8(pixels),
+            PixelFormat::Gray8 => self.do_encode_gray8(pixels),
+            PixelFormat::Rgb16 => self.do_encode_rgb16(pixels),
+            PixelFormat::Rgba16 => self.do_encode_rgba16(pixels),
+            PixelFormat::RgbF32 => self.do_encode_rgb_f32(pixels),
+            PixelFormat::RgbaF32 => self.do_encode_rgba_f32(pixels),
+            PixelFormat::GrayF32 => self.do_encode_gray_f32(pixels),
+            PixelFormat::Bgra8 => {
+                // Swizzle BGRA → RGBA and encode
+                let raw = pixels.contiguous_bytes();
+                let w = pixels.width() as usize;
+                let h = pixels.rows() as usize;
+                self.check_limits(w, h, 4)?;
+                let cfg = self.build_config();
+                let stop = self.stop_token();
+                let rgba: Vec<Rgba<u8>> = raw
+                    .chunks_exact(4)
+                    .map(|c| Rgba {
+                        r: c[2],
+                        g: c[1],
+                        b: c[0],
+                        a: c[3],
+                    })
+                    .collect();
+                let img = imgref::ImgVec::new(rgba, w, h);
+                let result = crate::encode_rgba8(img.as_ref(), &cfg, stop)?;
+                self.make_output(result.avif_file)
+            }
+            PixelFormat::Rgbx8 => {
+                // Byte 3 is padding — strip to 3-channel RGB.
+                let raw = pixels.contiguous_bytes();
+                let w = pixels.width() as usize;
+                let h = pixels.rows() as usize;
+                self.check_limits(w, h, 3)?;
+                let cfg = self.build_config();
+                let stop = self.stop_token();
+                let rgb: Vec<Rgb<u8>> = raw
+                    .chunks_exact(4)
+                    .map(|c| Rgb {
+                        r: c[0],
+                        g: c[1],
+                        b: c[2],
+                    })
+                    .collect();
+                let img = imgref::ImgVec::new(rgb, w, h);
+                let result = crate::encode_rgb8(img.as_ref(), &cfg, stop)?;
+                self.make_output(result.avif_file)
+            }
+            PixelFormat::Bgrx8 => {
+                // BGRA layout with padding byte — swap B↔R and strip to RGB.
+                let raw = pixels.contiguous_bytes();
+                let w = pixels.width() as usize;
+                let h = pixels.rows() as usize;
+                self.check_limits(w, h, 3)?;
+                let cfg = self.build_config();
+                let stop = self.stop_token();
+                let rgb: Vec<Rgb<u8>> = raw
+                    .chunks_exact(4)
+                    .map(|c| Rgb {
+                        r: c[2],
+                        g: c[1],
+                        b: c[0],
+                    })
+                    .collect();
+                let img = imgref::ImgVec::new(rgb, w, h);
+                let result = crate::encode_rgb8(img.as_ref(), &cfg, stop)?;
+                self.make_output(result.avif_file)
+            }
+            _ => Err(at!(Error::UnsupportedOperation(
+                zencodec::UnsupportedOperation::PixelFormat,
+            ))),
+        }
+    }
+}
+
+#[cfg(feature = "encode")]
+impl AvifAnimationFrameEncoder {
+    fn push_frame_inner(
+        &mut self,
+        pixels: PixelSlice<'_>,
+        duration_ms: u32,
+        stop: Option<&dyn Stop>,
+    ) -> Result<(), At<Error>> {
+        // Check cancellation (combine per-call + owned stop)
+        if let Some(s) = stop {
+            s.check().map_err(|e| at!(Error::from(e)))?;
+        }
+        if let Some(ref s) = self.stop {
+            s.check().map_err(|e| at!(Error::from(e)))?;
+        }
+
+        let w = pixels.width();
+        let h = pixels.rows();
+
+        // Validate canvas dimensions match
+        match (self.canvas_width, self.canvas_height) {
+            (Some(cw), Some(ch)) if cw != w || ch != h => {
+                return Err(at!(Error::Encode(format!(
+                    "frame dimensions {}x{} don't match canvas {}x{}",
+                    w, h, cw, ch
+                ))));
+            }
+            (None, None) => {
+                self.canvas_width = Some(w);
+                self.canvas_height = Some(h);
+            }
+            _ => {}
+        }
+
+        // Check resource limits
+        let desc = pixels.descriptor();
+        let bpp = desc.bytes_per_pixel() as u64;
+        self.limits.check_dimensions(w, h).map_err(|_| {
+            at!(Error::ImageTooLarge {
+                width: w,
+                height: h,
+            })
+        })?;
+        self.limits
+            .check_memory(w as u64 * h as u64 * bpp)
+            .map_err(|e| at!(Error::Encode(format!("{e}"))))?;
+
+        // Enforce max_frames limit.
+        self.frame_count += 1;
+        self.limits
+            .check_frames(self.frame_count)
+            .map_err(|e| at!(Error::Encode(format!("{e}"))))?;
+
+        let fmt = desc.pixel_format();
+
+        // Validate consistent pixel format across frames
+        if let Some(expected) = self.pixel_format {
+            if fmt != expected {
+                return Err(at!(Error::Encode(format!(
+                    "pixel format mismatch: first frame was {expected:?}, this frame is {fmt:?}"
+                ))));
+            }
+        } else {
+            self.pixel_format = Some(fmt);
+        }
+
+        let raw = pixels.contiguous_bytes();
+        let wu = w as usize;
+        let hu = h as usize;
+
+        let frame = match fmt {
+            zenpixels::PixelFormat::Rgb8 => {
+                let rgb: Vec<Rgb<u8>> = bytemuck::cast_slice(&raw).to_vec();
+                BufferedFrame::Rgb8 {
+                    pixels: imgref::ImgVec::new(rgb, wu, hu),
+                    duration_ms,
+                }
+            }
+            zenpixels::PixelFormat::Rgba8 => {
+                let rgba: Vec<Rgba<u8>> = bytemuck::cast_slice(&raw).to_vec();
+                BufferedFrame::Rgba8 {
+                    pixels: imgref::ImgVec::new(rgba, wu, hu),
+                    duration_ms,
+                }
+            }
+            zenpixels::PixelFormat::Rgb16 => {
+                let rgb: Vec<Rgb<u16>> = bytemuck::cast_slice(&raw).to_vec();
+                BufferedFrame::Rgb16 {
+                    pixels: imgref::ImgVec::new(rgb, wu, hu),
+                    duration_ms,
+                }
+            }
+            zenpixels::PixelFormat::Rgba16 => {
+                let rgba: Vec<Rgba<u16>> = bytemuck::cast_slice(&raw).to_vec();
+                BufferedFrame::Rgba16 {
+                    pixels: imgref::ImgVec::new(rgba, wu, hu),
+                    duration_ms,
+                }
+            }
+            _ => {
+                return Err(at!(Error::UnsupportedOperation(
+                    zencodec::UnsupportedOperation::PixelFormat,
+                )));
+            }
+        };
+
+        self.frames.push(frame);
+        Ok(())
+    }
+
+    fn finish_inner(self, stop: Option<&dyn Stop>) -> Result<EncodeOutput, At<Error>> {
+        if let Some(s) = stop {
+            s.check().map_err(|e| at!(Error::from(e)))?;
+        }
+        if let Some(ref s) = self.stop {
+            s.check().map_err(|e| at!(Error::from(e)))?;
+        }
+
+        if self.frames.is_empty() {
+            return Err(at!(Error::Encode("no frames to encode".into())));
+        }
+
+        let stop_token = self.stop_token();
+
+        let avif_file = match self.frames[0] {
+            BufferedFrame::Rgb8 { .. } => {
+                let anim_frames: Vec<crate::AnimationFrame> = self
+                    .frames
+                    .into_iter()
+                    .map(|f| match f {
+                        BufferedFrame::Rgb8 {
+                            pixels,
+                            duration_ms,
+                        } => crate::AnimationFrame {
+                            pixels,
+                            duration_ms,
+                        },
+                        _ => unreachable!(),
+                    })
+                    .collect();
+                let result =
+                    crate::encode_animation_rgb8(&anim_frames, &self.config, stop_token.clone())?;
+                result.avif_file
+            }
+            BufferedFrame::Rgba8 { .. } => {
+                let anim_frames: Vec<crate::AnimationFrameRgba> = self
+                    .frames
+                    .into_iter()
+                    .map(|f| match f {
+                        BufferedFrame::Rgba8 {
+                            pixels,
+                            duration_ms,
+                        } => crate::AnimationFrameRgba {
+                            pixels,
+                            duration_ms,
+                        },
+                        _ => unreachable!(),
+                    })
+                    .collect();
+                let result =
+                    crate::encode_animation_rgba8(&anim_frames, &self.config, stop_token.clone())?;
+                result.avif_file
+            }
+            BufferedFrame::Rgb16 { .. } => {
+                let anim_frames: Vec<crate::AnimationFrame16> = self
+                    .frames
+                    .into_iter()
+                    .map(|f| match f {
+                        BufferedFrame::Rgb16 {
+                            pixels,
+                            duration_ms,
+                        } => crate::AnimationFrame16 {
+                            pixels,
+                            duration_ms,
+                        },
+                        _ => unreachable!(),
+                    })
+                    .collect();
+                let result =
+                    crate::encode_animation_rgb16(&anim_frames, &self.config, stop_token.clone())?;
+                result.avif_file
+            }
+            BufferedFrame::Rgba16 { .. } => {
+                let anim_frames: Vec<crate::AnimationFrameRgba16> = self
+                    .frames
+                    .into_iter()
+                    .map(|f| match f {
+                        BufferedFrame::Rgba16 {
+                            pixels,
+                            duration_ms,
+                        } => crate::AnimationFrameRgba16 {
+                            pixels,
+                            duration_ms,
+                        },
+                        _ => unreachable!(),
+                    })
+                    .collect();
+                let result =
+                    crate::encode_animation_rgba16(&anim_frames, &self.config, stop_token.clone())?;
+                result.avif_file
+            }
+        };
+
+        self.limits
+            .check_output_size(avif_file.len() as u64)
+            .map_err(|e| at!(Error::Encode(format!("{e}"))))?;
+
+        Ok(EncodeOutput::new(avif_file, ImageFormat::Avif))
+    }
+}
+
+impl AvifDecodeJob {
+    fn probe_inner(&self, data: &[u8]) -> Result<ImageInfo, At<Error>> {
+        let decoder = crate::ManagedAvifDecoder::new(data, &self.config.inner)?;
+        let native_info = decoder.probe_info()?;
+        // `convert_native_info` reports the Preserve view (stored dims +
+        // intrinsic tag); rewrite to display dims + Identity on the bake path.
+        let mut info = apply_reported_orientation(
+            convert_native_info(&native_info),
+            &native_info,
+            self.orientation,
+        );
+        // Detect animation from the container's track structure.
+        if let Some(anim) = decoder.animation_info() {
+            info = info.with_sequence(ImageSequence::Animation {
+                frame_count: Some(anim.frame_count as u32),
+                loop_count: Some(anim.loop_count),
+                random_access: true,
+            });
+        }
+        if let Ok(probe) = crate::detect::probe(data) {
+            info = info.with_source_encoding_details(probe);
+        }
+        if let Some(ref policy) = self.policy {
+            apply_decode_policy(&mut info, policy);
+        }
+        Ok(info)
+    }
+
+    fn output_info_inner(&self, data: &[u8]) -> Result<zencodec::decode::OutputInfo, At<Error>> {
+        let decoder = crate::ManagedAvifDecoder::new(data, &self.config.inner)?;
+        let native_info = decoder.probe_info()?;
+        let mut desc = if native_info.bit_depth > 8 {
+            if native_info.has_alpha {
+                PixelDescriptor::RGBA16_SRGB
+            } else {
+                PixelDescriptor::RGB16_SRGB
+            }
+        } else if native_info.has_alpha {
+            PixelDescriptor::RGBA8_SRGB
+        } else {
+            PixelDescriptor::RGB8_SRGB
+        };
+        // Override TF and primaries from CICP if available.
+        if let Some(tf) =
+            zenpixels::TransferFunction::from_cicp(native_info.transfer_characteristics.0)
+        {
+            desc = desc.with_transfer(tf);
+        }
+        if let Some(p) = zenpixels::ColorPrimaries::from_cicp(native_info.color_primaries.0) {
+            desc = desc.with_primaries(p);
+        }
+        // Report the post-orientation output dims + what the decoder bakes:
+        // `Correct` bakes the intrinsic orientation (output = display dims,
+        // `orientation_applied` = intrinsic); `Preserve` bakes nothing
+        // (output = stored dims, `orientation_applied` = Identity, caller orients).
+        let (w, h, _) = reported_dims_and_orientation(&native_info, self.orientation);
+        let orientation_applied = if will_auto_orient(self.orientation) {
+            intrinsic_orientation(&native_info)
+        } else {
+            zencodec::Orientation::Identity
+        };
+        Ok(zencodec::decode::OutputInfo::full_decode(w, h, desc)
+            .with_orientation_applied(orientation_applied))
+    }
+
+    fn decoder_inner<'a>(
+        self,
+        data: Cow<'a, [u8]>,
+        preferred: &[PixelDescriptor],
+    ) -> Result<AvifDecoder<'a>, At<Error>> {
+        self.check_input_size(&data)?;
+        let cfg = self.effective_config();
+        Ok(AvifDecoder {
+            config: cfg,
+            stop: self.stop,
+            data,
+            preferred: preferred.to_vec(),
+            limits: self.limits,
+            policy: self.policy,
+            extract_gain_map: self.extract_gain_map,
+            gain_map_render: self.gain_map_render,
+            orientation: self.orientation,
+        })
+    }
+
+    fn streaming_decoder_inner<'a>(
+        mut self,
+        data: Cow<'a, [u8]>,
+        preferred: &[PixelDescriptor],
+    ) -> Result<AvifStreamingDecoder, At<Error>> {
+        self.check_input_size(&data)?;
+        let cfg = self.effective_config();
+        let stop_token = self
+            .stop
+            .take()
+            .unwrap_or_else(|| zencodec::StopToken::new(enough::Unstoppable));
+
+        let mut decoder = crate::ManagedAvifDecoder::new(&data, &cfg)?;
+        let native_info = decoder.probe_info()?;
+        self.check_decode_limits(&native_info)?;
+
+        // Native grayscale opt-in (zenavif#5) — mirrors the buffered
+        // decode: alpha-free monochrome, not reconstructing, not a grid
+        // (the grid branch below stitches RGB tiles), gray negotiated.
+        // The monochrome strip path runs through full conversion +
+        // `StripConverter::new_from_pixels`, which carries the gray
+        // descriptor into the emitted strips.
+        let mono_source = native_info.monochrome && !native_info.has_alpha;
+        let reconstructing = matches!(
+            self.gain_map_render,
+            zencodec::GainMapRender::ReconstructHdr { .. }
+        ) && native_info.gain_map.is_some();
+        if mono_source
+            && !reconstructing
+            && !decoder.is_grid()
+            && icc_allows_native_gray(&native_info)
+            && wants_gray_output(preferred)
+        {
+            decoder.set_native_gray(true);
+        }
+
+        // ReconstructHdr path: gain-map application is whole-image (the
+        // map is sampled at an image-to-map scale ratio), so decode the
+        // full buffer, reconstruct, then emit fixed-height strips —
+        // same shape as the orientation-bake path below. Files without
+        // a gain map fall through to honest SDR streaming.
+        if let zencodec::GainMapRender::ReconstructHdr { target_headroom } = self.gain_map_render
+            && native_info.gain_map.is_some()
+        {
+            let (pixels, native_info) = decoder.decode_full(&stop_token)?;
+            let pixels = set_cicp_on_pixels(pixels, &native_info);
+            let pixels = attach_source_color_context(pixels, &native_info);
+            let (hdr, (max_cll, max_fall)) =
+                reconstruct_hdr_pixels(pixels, &native_info, target_headroom, &stop_token)?;
+            let (baked, _orientation, w, h) = bake_orientation(hdr, &native_info, self.orientation);
+            let strip_descriptor = baked.descriptor();
+            let mut info = apply_reported_orientation(
+                convert_native_info(&native_info),
+                &native_info,
+                self.orientation,
+            );
+            // Measured envelope of the reconstructed pixels (zencodec
+            // contract: MaxCLL/MaxFALL are measured; mastering display
+            // passes through unchanged).
+            info =
+                info.with_content_light_level(zencodec::ContentLightLevel::new(max_cll, max_fall));
+            let strip_height = 64u32.min(h.max(1));
+            return Ok(AvifStreamingDecoder {
+                info,
+                y_offset: 0,
+                output_width: w,
+                output_height: h,
+                decoder: None,
+                stop: stop_token,
+                grid_rows: 0,
+                grid_cols: 0,
+                current_grid_row: 0,
+                strip_descriptor,
+                strip_buffer: None,
+                strip_converter: None,
+                strip_height,
+                strip_color_context: baked.color_context().cloned(),
+                baked: Some(baked),
+            });
+        }
+
+        // Bake path: orientation is not strip-local (transposes need the whole
+        // image), so decode + bake the full buffer once and emit it in
+        // fixed-height strips. Mirrors `Decode::decode`'s buffer pipeline. The
+        // preserve path (default) falls through to the low-memory grid / strip-
+        // converter streaming below, unchanged.
+        if will_auto_orient(self.orientation) {
+            let (pixels, native_info) = decoder.decode_full(&stop_token)?;
+            let pixels = set_cicp_on_pixels(pixels, &native_info);
+            let pixels = attach_source_color_context(pixels, &native_info);
+            let pixels = negotiate_format(
+                pixels,
+                preferred,
+                native_info.monochrome && !native_info.has_alpha,
+            );
+            let (baked, _orientation, w, h) =
+                bake_orientation(pixels, &native_info, self.orientation);
+            let strip_descriptor = baked.descriptor();
+            let info = apply_reported_orientation(
+                convert_native_info(&native_info),
+                &native_info,
+                self.orientation,
+            );
+            // Emit in cache-friendly fixed-height strips (or the whole image if
+            // it's short). The baked buffer is contiguous, so a strip is just a
+            // row-range view re-copied into a small buffer.
+            let strip_height = 64u32.min(h.max(1));
+            return Ok(AvifStreamingDecoder {
+                info,
+                y_offset: 0,
+                output_width: w,
+                output_height: h,
+                decoder: None,
+                stop: stop_token,
+                grid_rows: 0,
+                grid_cols: 0,
+                current_grid_row: 0,
+                strip_descriptor,
+                strip_buffer: None,
+                strip_converter: None,
+                strip_height,
+                strip_color_context: baked.color_context().cloned(),
+                baked: Some(baked),
+            });
+        }
+
+        let info = convert_native_info(&native_info);
+
+        if decoder.is_grid() {
+            let grid = decoder
+                .grid_config()
+                .ok_or_else(|| at!(Error::Unsupported("grid_config missing after is_grid()")))?;
+            let output_width = grid.output_width;
+            let output_height = grid.output_height;
+
+            let base_desc = if native_info.bit_depth > 8 {
+                if native_info.has_alpha {
+                    PixelDescriptor::RGBA16_SRGB
+                } else {
+                    PixelDescriptor::RGB16_SRGB
+                }
+            } else if native_info.has_alpha {
+                PixelDescriptor::RGBA8_SRGB
+            } else {
+                PixelDescriptor::RGB8_SRGB
+            };
+
+            // Apply CICP metadata to descriptor. No format negotiation for
+            // the grid path — tiles produce native format and we stitch raw bytes.
+            let mut strip_descriptor = base_desc;
+            if let Some(tf) =
+                zenpixels::TransferFunction::from_cicp(native_info.transfer_characteristics.0)
+            {
+                strip_descriptor = strip_descriptor.with_transfer(tf);
+            }
+            if let Some(p) = zenpixels::ColorPrimaries::from_cicp(native_info.color_primaries.0) {
+                strip_descriptor = strip_descriptor.with_primaries(p);
+            }
+
+            return Ok(AvifStreamingDecoder {
+                info,
+                y_offset: 0,
+                output_width,
+                output_height,
+                decoder: Some(decoder),
+                stop: stop_token,
+                grid_rows: grid.rows as u32,
+                grid_cols: grid.columns as u32,
+                current_grid_row: 0,
+                strip_descriptor,
+                strip_buffer: None,
+                strip_converter: None,
+                strip_height: 0,
+                strip_color_context: color_context_for_layout(
+                    &native_source_color(&native_info),
+                    strip_descriptor.layout(),
+                ),
+                baked: None,
+            });
+        }
+
+        // Non-grid: decode YUV, set up strip converter for on-demand conversion.
+        // Use the frame-era info the converter returns (not the probe-era
+        // one): the buffered path attaches its context from decode_full's
+        // info, and strips must describe pixels identically.
+        let (converter, frame_native) = decoder.decode_to_strip_converter(&stop_token)?;
+        let desc = converter.descriptor();
+        let w = converter.display_width() as u32;
+        let h = converter.display_height() as u32;
+        let strip_h = converter.optimal_strip_height() as u32;
+
+        Ok(AvifStreamingDecoder {
+            info,
+            y_offset: 0,
+            output_width: w,
+            output_height: h,
+            decoder: None,
+            stop: stop_token,
+            grid_rows: 0,
+            grid_cols: 0,
+            current_grid_row: 0,
+            strip_descriptor: desc,
+            strip_buffer: None,
+            strip_converter: Some(converter),
+            strip_height: strip_h,
+            strip_color_context: color_context_for_layout(
+                &native_source_color(&frame_native),
+                desc.layout(),
+            ),
+            baked: None,
+        })
+    }
+
+    fn animation_frame_decoder_inner<'a>(
+        self,
+        data: Cow<'a, [u8]>,
+        preferred: &[PixelDescriptor],
+    ) -> Result<AvifAnimationFrameDecoder, At<Error>> {
+        // Reject animation when policy disallows it.
+        if let Some(ref policy) = self.policy
+            && !policy.resolve_animation(true)
+        {
+            return Err(at!(Error::UnsupportedOperation(
+                zencodec::UnsupportedOperation::AnimationDecode,
+            )));
+        }
+        self.check_input_size(&data)?;
+        let cfg = self.effective_config();
+
+        // Probe metadata before creating animation decoder (both parse the container,
+        // but ManagedAvifDecoder gives us the native ImageInfo for conversion).
+        let probe_dec = crate::ManagedAvifDecoder::new(&data, &cfg)?;
+        let native_info = probe_dec.probe_info()?;
+        self.check_decode_limits(&native_info)?;
+        drop(probe_dec);
+
+        let anim_dec = crate::AnimationDecoder::new(&data, &cfg)?;
+        let anim_info = anim_dec.info().clone();
+
+        // `convert_native_info` reports the Preserve view (stored dims +
+        // intrinsic tag); the bake path rewrites the canvas to display dims +
+        // Identity, matching the per-frame buffers `render_next_frame` bakes.
+        let mut base_info = apply_reported_orientation(
+            convert_native_info(&native_info),
+            &native_info,
+            self.orientation,
+        )
+        .with_sequence(ImageSequence::Animation {
+            frame_count: Some(anim_info.frame_count as u32),
+            loop_count: Some(anim_info.loop_count),
+            random_access: true,
+        });
+        // Attach source encoding details to the shared animation ImageInfo.
+        if let Ok(probe) = crate::detect::probe(&data) {
+            base_info = base_info.with_source_encoding_details(probe);
+        }
+        if let Some(ref policy) = self.policy {
+            apply_decode_policy(&mut base_info, policy);
+        }
+
+        // Resolve the orientation to bake into each frame: the intrinsic
+        // transform on the bake path, `Identity` (no-op) on the preserve path.
+        let bake_to = if will_auto_orient(self.orientation) {
+            intrinsic_orientation(&native_info)
+        } else {
+            zencodec::Orientation::Identity
+        };
+
+        Ok(AvifAnimationFrameDecoder {
+            anim_decoder: anim_dec,
+            index: 0,
+            frames_decoded: 0,
+            start_frame_index: self.start_frame_index,
+            info: Arc::new(base_info),
+            total_frames: anim_info.frame_count as u32,
+            loop_count: anim_info.loop_count,
+            preferred: preferred.to_vec(),
+            current_frame: None,
+            limits: self.limits,
+            accumulated_ms: 0,
+            bake_to,
+        })
+    }
+
+    fn push_decoder_inner(
+        self,
+        data: Cow<'_, [u8]>,
+        sink: &mut dyn zencodec::decode::DecodeRowSink,
+    ) -> Result<zencodec::decode::OutputInfo, At<Error>> {
+        self.check_input_size(&data)?;
+        let cfg = self.effective_config();
+        let stop: &dyn Stop = match &self.stop {
+            Some(s) => s,
+            None => &enough::Unstoppable,
+        };
+        let mut decoder = crate::ManagedAvifDecoder::new(&data, &cfg)?;
+        let probe_info = decoder.probe_info()?;
+        self.check_decode_limits(&probe_info)?;
+        let native_info = decoder.decode_to_sink(stop, sink)?;
+
+        let desc = if native_info.bit_depth > 8 {
+            if native_info.has_alpha {
+                PixelDescriptor::RGBA16_SRGB
+            } else {
+                PixelDescriptor::RGB16_SRGB
+            }
+        } else if native_info.has_alpha {
+            PixelDescriptor::RGBA8_SRGB
+        } else {
+            PixelDescriptor::RGB8_SRGB
+        };
+        Ok(zencodec::decode::OutputInfo::full_decode(
+            native_info.width,
+            native_info.height,
+            desc,
+        ))
+    }
+}
+
+impl AvifDecoder<'_> {
+    fn decode_inner(self) -> Result<DecodeOutput, At<Error>> {
         let stop: &dyn Stop = match &self.stop {
             Some(s) => s,
             None => &enough::Unstoppable,
@@ -3524,87 +3791,8 @@ impl zencodec::decode::Decode for AvifDecoder<'_> {
     }
 }
 
-/// Streaming AVIF decoder with real tile-row streaming for grid images.
-///
-/// For grid (tiled) images, each [`next_batch`](zencodec::decode::StreamingDecode::next_batch)
-/// call decodes one tile-row of AV1 tiles, color-converts them, and stitches
-/// them into a strip. Peak memory is proportional to one tile-row instead of
-/// the full image.
-///
-/// For non-grid 8-bit color images, the decoded YUV frame is held in memory
-/// and converted strip-by-strip on demand. This eliminates the full RGB
-/// allocation and keeps the working set in L2 cache.
-///
-/// For non-grid 16-bit or monochrome images, falls back to full-frame
-/// conversion and emits fixed-height strips.
-pub struct AvifStreamingDecoder {
-    info: ImageInfo,
-    y_offset: u32,
-    output_width: u32,
-    output_height: u32,
-    /// Grid path: managed decoder for tile-row streaming.
-    decoder: Option<crate::ManagedAvifDecoder>,
-    /// Stop token for cancellable grid decoding.
-    stop: zencodec::StopToken,
-    grid_rows: u32,
-    grid_cols: u32,
-    current_grid_row: u32,
-    /// Pixel descriptor with CICP metadata for strip buffers.
-    strip_descriptor: PixelDescriptor,
-    /// Reusable strip buffer for the current tile-row or strip conversion.
-    strip_buffer: Option<PixelBuffer>,
-    /// Non-grid strip conversion: holds decoded YUV frames, converts on demand.
-    strip_converter: Option<crate::strip_convert::StripConverter>,
-    /// Optimal strip height for the strip converter path.
-    strip_height: u32,
-    /// Class-gated color context applied to every emitted strip: the
-    /// scratch `strip_buffer` is rebuilt per batch without one, so the
-    /// context is re-attached at emission. `None` when the source
-    /// carries no color signaling (or the HDR/bake source buffer had
-    /// none).
-    strip_color_context: Option<Arc<zenpixels::ColorContext>>,
-    /// Bake path (`OrientationHint::bakes()`): the fully-decoded, orientation-
-    /// baked buffer. Orientation is not strip-local (transposes need the whole
-    /// image), so the bake path materializes upright once and emits it in
-    /// fixed-height strips. `None` on the preserve path (the default), where the
-    /// grid / strip-converter fields drive low-memory streaming unchanged.
-    baked: Option<PixelBuffer>,
-}
-
 impl AvifStreamingDecoder {
-    /// Stitch decoded tiles horizontally into `self.strip_buffer`.
-    fn stitch_tiles(&mut self, tiles: &[PixelBuffer], strip_h: u32) {
-        let bpp = self.strip_descriptor.bytes_per_pixel();
-        let mut strip = PixelBuffer::new(self.output_width, strip_h, self.strip_descriptor);
-        {
-            let mut sm = strip.as_slice_mut();
-            for py in 0..strip_h {
-                let dst_row = sm.row_mut(py);
-                let mut x_offset = 0usize;
-                for tile in tiles {
-                    let tile_w = tile.width() as usize;
-                    let actual_w =
-                        tile_w.min((self.output_width as usize).saturating_sub(x_offset));
-                    if actual_w == 0 {
-                        continue;
-                    }
-                    let tile_slice = tile.as_slice();
-                    let src = tile_slice.row(py);
-                    let copy_bytes = actual_w * bpp;
-                    let dst_start = x_offset * bpp;
-                    dst_row[dst_start..dst_start + copy_bytes].copy_from_slice(&src[..copy_bytes]);
-                    x_offset += tile_w;
-                }
-            }
-        }
-        self.strip_buffer = Some(strip);
-    }
-}
-
-impl zencodec::decode::StreamingDecode for AvifStreamingDecoder {
-    type Error = At<Error>;
-
-    fn next_batch(&mut self) -> Result<Option<(u32, PixelSlice<'_>)>, At<Error>> {
+    fn next_batch_inner(&mut self) -> Result<Option<(u32, PixelSlice<'_>)>, At<Error>> {
         if self.y_offset >= self.output_height {
             return Ok(None);
         }
@@ -3714,66 +3902,10 @@ impl zencodec::decode::StreamingDecode for AvifStreamingDecoder {
 
         Ok(None)
     }
-
-    fn info(&self) -> &ImageInfo {
-        &self.info
-    }
 }
 
-// ── Frame Decoder ───────────────────────────────────────────────────────────
-
-/// Animation AVIF full-frame decoder.
-///
-/// Lazily decodes frames on demand. The `AnimationFrameDecoder` trait doesn't pass
-/// a stop token per-call, so per-frame cancellation is not available
-/// through this interface (use the native `AnimationDecoder` API for that).
-pub struct AvifAnimationFrameDecoder {
-    anim_decoder: crate::AnimationDecoder,
-    index: usize,
-    /// Number of frames decoded so far (including skipped ones).
-    frames_decoded: u32,
-    /// Skip frames before this index. Frames are still decoded to maintain
-    /// correct compositing state, but not yielded to the caller.
-    start_frame_index: u32,
-    info: Arc<ImageInfo>,
-    total_frames: u32,
-    /// Animation loop count (0 = infinite, n = play n times).
-    loop_count: u32,
-    preferred: Vec<PixelDescriptor>,
-    /// Holds the current frame's pixels so `render_next_frame` can return
-    /// a borrowing `AnimationFrame<'_>`.
-    current_frame: Option<PixelBuffer>,
-    /// Resource limits for frame count and animation duration enforcement.
-    limits: ResourceLimits,
-    /// Accumulated animation duration in milliseconds across all decoded frames.
-    accumulated_ms: u64,
-    /// Orientation to bake into every frame: the intrinsic `irot`/`imir`
-    /// transform on the bake path (`OrientationHint::bakes()`), or `Identity`
-    /// (no-op) on the preserve path (the default). Applied after format
-    /// negotiation, before the frame is yielded.
-    bake_to: zencodec::Orientation,
-}
-
-impl zencodec::decode::AnimationFrameDecoder for AvifAnimationFrameDecoder {
-    type Error = At<Error>;
-
-    fn wrap_sink_error(err: zencodec::decode::SinkError) -> Self::Error {
-        at!(Error::ResourceLimit(err.to_string()))
-    }
-
-    fn info(&self) -> &ImageInfo {
-        &self.info
-    }
-
-    fn frame_count(&self) -> Option<u32> {
-        Some(self.total_frames)
-    }
-
-    fn loop_count(&self) -> Option<u32> {
-        Some(self.loop_count)
-    }
-
-    fn render_next_frame(
+impl AvifAnimationFrameDecoder {
+    fn render_next_frame_inner(
         &mut self,
         stop: Option<&dyn zencodec::enough::Stop>,
     ) -> Result<Option<AnimationFrame<'_>>, At<Error>> {
@@ -3822,14 +3954,6 @@ impl zencodec::decode::AnimationFrameDecoder for AvifAnimationFrameDecoder {
             let slice = self.current_frame.as_ref().unwrap().as_slice().erase();
             return Ok(Some(AnimationFrame::new(slice, duration_ms, idx)));
         }
-    }
-
-    fn render_next_frame_to_sink(
-        &mut self,
-        stop: Option<&dyn zencodec::enough::Stop>,
-        sink: &mut dyn zencodec::decode::DecodeRowSink,
-    ) -> Result<Option<zencodec::decode::OutputInfo>, Self::Error> {
-        zencodec::helpers::copy_frame_to_sink(self, stop, sink)
     }
 }
 
@@ -3888,11 +4012,11 @@ mod tests {
     /// byte-identical output. Uses a real 8-bit 4:2:0 photo fixture, which
     /// exercises the big full-image RGB output buffer + the per-row scratch.
     mod alloc_pref_decode {
-        use super::super::{AvifDecoderConfig, DecodeOutput, Error};
+        use super::super::{AvifDecoderConfig, DecodeOutput};
         use alloc::borrow::Cow;
         use whereat::At;
         use zencodec::decode::{Decode as _, DecodeJob as _, DecoderConfig as _};
-        use zencodec::{AllocPreference, ResourceLimits};
+        use zencodec::{AllocPreference, CodecError, ResourceLimits};
 
         extern crate alloc;
 
@@ -3903,7 +4027,7 @@ mod tests {
         fn decode_bytes(
             encoded: &[u8],
             pref: Option<AllocPreference>,
-        ) -> Result<Vec<u8>, At<Error>> {
+        ) -> Result<Vec<u8>, At<CodecError>> {
             let job = AvifDecoderConfig::new().job();
             let job = match pref {
                 Some(p) => {
@@ -5460,10 +5584,21 @@ mod tests {
         };
         assert!(result.is_err(), "expected error from memory limit");
         let err = result.err().unwrap();
+        // Pattern B (envelope): the coarse category is read off `At<CodecError>`
+        // directly (native `Error::ResourceLimit` maps to `LimitsExceeded(Memory)`),
+        // and the native detail stays reachable via downcast — faithful to the
+        // original `matches!(.., Error::ResourceLimit(_))` intent.
+        assert_eq!(
+            err.error().category(),
+            zencodec::ErrorCategory::LimitsExceeded(zencodec::LimitKind::Memory),
+            "expected a memory LimitsExceeded category, got: {err}"
+        );
         assert!(
-            matches!(err.error(), Error::ResourceLimit(_)),
-            "expected Error::ResourceLimit, got: {}",
-            err
+            matches!(
+                err.error().detail().and_then(|d| d.downcast_ref::<Error>()),
+                Some(Error::ResourceLimit(_))
+            ),
+            "envelope must carry the native Error::ResourceLimit detail, got: {err}"
         );
     }
 
@@ -5496,10 +5631,21 @@ mod tests {
             .decoder(Cow::Borrowed(encoded.data()), &[]);
         assert!(result.is_err(), "expected error from memory limit");
         let err = result.err().unwrap();
+        // Pattern B (envelope): the coarse category is read off `At<CodecError>`
+        // directly (native `Error::ResourceLimit` maps to `LimitsExceeded(Memory)`),
+        // and the native detail stays reachable via downcast — faithful to the
+        // original `matches!(.., Error::ResourceLimit(_))` intent.
+        assert_eq!(
+            err.error().category(),
+            zencodec::ErrorCategory::LimitsExceeded(zencodec::LimitKind::Memory),
+            "expected a memory LimitsExceeded category, got: {err}"
+        );
         assert!(
-            matches!(err.error(), Error::ResourceLimit(_)),
-            "expected Error::ResourceLimit, got: {}",
-            err
+            matches!(
+                err.error().detail().and_then(|d| d.downcast_ref::<Error>()),
+                Some(Error::ResourceLimit(_))
+            ),
+            "envelope must carry the native Error::ResourceLimit detail, got: {err}"
         );
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -525,7 +525,7 @@ impl AvifDecoder {
             &parse_config,
             &enough::Unstoppable,
         )
-        .map_err(|e| at!(Error::Parse(e)))?;
+        .map_err(|e| e.map_error(Error::Parse))?;
 
         // Extract metadata from the parsed AVIF. Like the default rav1d-safe
         // backend (decoder_managed), tolerate a metadata-parse failure here: a
@@ -614,7 +614,7 @@ impl AvifDecoder {
         let primary_data = self
             .parser
             .primary_data()
-            .map_err(|e| at!(Error::Parse(e)))?;
+            .map_err(|e| e.map_error(Error::Parse))?;
         let color_picture = decoder.decode(&primary_data)?;
 
         // Check for cancellation after color decode
@@ -698,7 +698,7 @@ impl AvifDecoder {
 
         // Decode alpha channel if present
         if let Some(alpha_result) = self.parser.alpha_data() {
-            let alpha_data = alpha_result.map_err(|e| at!(Error::Parse(e)))?;
+            let alpha_data = alpha_result.map_err(|e| e.map_error(Error::Parse))?;
             let alpha_picture = decoder.decode(&alpha_data)?;
 
             let alpha_color_range = alpha_picture
@@ -1028,7 +1028,9 @@ impl AvifDecoder {
         has_alpha: bool,
     ) -> Result<PixelBuffer> {
         let (width, height) = (planes.width, planes.height);
-        let pixel_count = width.checked_mul(height).ok_or_else(|| at!(Error::OutOfMemory))?;
+        let pixel_count = width
+            .checked_mul(height)
+            .ok_or_else(|| at!(Error::OutOfMemory))?;
         let limited = matches!(yuv_range, YuvRange::Limited);
         // H.273 full-range-flag: limited identity uses the luma range (16–235)
         // on all three planes.
@@ -1079,7 +1081,9 @@ impl AvifDecoder {
         has_alpha: bool,
     ) -> Result<PixelBuffer> {
         let (width, height) = (planes.width, planes.height);
-        let pixel_count = width.checked_mul(height).ok_or_else(|| at!(Error::OutOfMemory))?;
+        let pixel_count = width
+            .checked_mul(height)
+            .ok_or_else(|| at!(Error::OutOfMemory))?;
         let limited = matches!(yuv_range, YuvRange::Limited);
         let max = (1u32 << bit_depth) - 1;
         let smin = 16u32 << (bit_depth - 8);

--- a/src/decoder_managed.rs
+++ b/src/decoder_managed.rs
@@ -149,7 +149,7 @@ impl ManagedAvifDecoder {
             &parse_config,
             &enough::Unstoppable,
         )
-        .map_err(|e| at!(Error::from(e)))?;
+        .map_err_at(Error::Parse)?;
 
         let mut settings = Settings::default();
         settings.threads = config.threads;
@@ -240,10 +240,7 @@ impl ManagedAvifDecoder {
             return self.decode_grid(stop);
         }
 
-        let primary_data = self
-            .parser
-            .primary_data()
-            .map_err(|e| at!(Error::from(e)))?;
+        let primary_data = self.parser.primary_data().map_err_at(Error::Parse)?;
         let primary_frame = Self::decode_frame(
             &mut self.decoder,
             &primary_data,
@@ -253,7 +250,7 @@ impl ManagedAvifDecoder {
         stop.check().map_err(|e| at!(Error::Cancelled(e)))?;
 
         let alpha_frame = if let Some(alpha_result) = self.parser.alpha_data() {
-            let alpha_data = alpha_result.map_err(|e| at!(Error::from(e)))?;
+            let alpha_data = alpha_result.map_err_at(Error::Parse)?;
             Some(Self::decode_frame(
                 &mut self.decoder,
                 &alpha_data,
@@ -279,10 +276,7 @@ impl ManagedAvifDecoder {
             return Ok((pixels, info));
         }
 
-        let primary_data = self
-            .parser
-            .primary_data()
-            .map_err(|e| at!(Error::from(e)))?;
+        let primary_data = self.parser.primary_data().map_err_at(Error::Parse)?;
         let primary_frame = Self::decode_frame(
             &mut self.decoder,
             &primary_data,
@@ -292,7 +286,7 @@ impl ManagedAvifDecoder {
         stop.check().map_err(|e| at!(Error::Cancelled(e)))?;
 
         let alpha_frame = if let Some(alpha_result) = self.parser.alpha_data() {
-            let alpha_data = alpha_result.map_err(|e| at!(Error::from(e)))?;
+            let alpha_data = alpha_result.map_err_at(Error::Parse)?;
             Some(Self::decode_frame(
                 &mut self.decoder,
                 &alpha_data,
@@ -322,10 +316,7 @@ impl ManagedAvifDecoder {
     ) -> Result<(crate::strip_convert::StripConverter, ImageInfo)> {
         stop.check().map_err(|e| at!(Error::Cancelled(e)))?;
 
-        let primary_data = self
-            .parser
-            .primary_data()
-            .map_err(|e| at!(Error::from(e)))?;
+        let primary_data = self.parser.primary_data().map_err_at(Error::Parse)?;
         let primary_frame = Self::decode_frame(
             &mut self.decoder,
             &primary_data,
@@ -335,7 +326,7 @@ impl ManagedAvifDecoder {
         stop.check().map_err(|e| at!(Error::Cancelled(e)))?;
 
         let alpha_frame = if let Some(alpha_result) = self.parser.alpha_data() {
-            let alpha_data = alpha_result.map_err(|e| at!(Error::from(e)))?;
+            let alpha_data = alpha_result.map_err_at(Error::Parse)?;
             Some(Self::decode_frame(
                 &mut self.decoder,
                 &alpha_data,
@@ -515,7 +506,6 @@ impl ManagedAvifDecoder {
     /// Does NOT do full AV1 frame decoding.
     /// Opt in to native grayscale output for alpha-free monochrome
     /// images (zencodec adapter negotiation; see `convert_*_monochrome_gray`).
-    #[cfg_attr(not(feature = "zencodec"), allow(dead_code))]
     pub(crate) fn set_native_gray(&mut self, on: bool) {
         self.native_gray = on;
     }
@@ -525,10 +515,7 @@ impl ManagedAvifDecoder {
         let (width, height) = if let Some(grid) = self.parser.grid_config() {
             (grid.output_width, grid.output_height)
         } else {
-            let meta = self
-                .parser
-                .primary_metadata()
-                .map_err(|e| at!(Error::from(e)))?;
+            let meta = self.parser.primary_metadata().map_err_at(Error::Parse)?;
             (meta.max_frame_width.get(), meta.max_frame_height.get())
         };
 
@@ -667,7 +654,7 @@ impl ManagedAvifDecoder {
         for i in 0..frame_count {
             stop.check().map_err(|e| at!(Error::Cancelled(e)))?;
 
-            let frame_ref = self.parser.frame(i).map_err(|e| at!(Error::from(e)))?;
+            let frame_ref = self.parser.frame(i).map_err_at(Error::Parse)?;
 
             let primary_frame = Self::decode_anim_frame(
                 &mut self.decoder,
@@ -756,7 +743,7 @@ impl ManagedAvifDecoder {
         for i in 0..self.parser.grid_tile_count() {
             stop.check().map_err(|e| at!(Error::Cancelled(e)))?;
 
-            let tile_data = self.parser.tile_data(i).map_err(|e| at!(Error::from(e)))?;
+            let tile_data = self.parser.tile_data(i).map_err_at(Error::Parse)?;
             let frame =
                 Self::decode_frame(&mut self.decoder, &tile_data, "Failed to decode grid tile")?;
 
@@ -1226,10 +1213,7 @@ impl ManagedAvifDecoder {
         let mut row_tiles = Vec::with_capacity(cols);
         for col in 0..cols {
             let tile_idx = grid_row * cols + col;
-            let tile_data = self
-                .parser
-                .tile_data(tile_idx)
-                .map_err(|e| at!(Error::from(e)))?;
+            let tile_data = self.parser.tile_data(tile_idx).map_err_at(Error::Parse)?;
             let frame =
                 Self::decode_frame(&mut self.decoder, &tile_data, "Failed to decode grid tile")?;
             let (pixels, _info) = self.convert_to_image(frame, None, stop)?;
@@ -1248,7 +1232,6 @@ impl ManagedAvifDecoder {
     /// full RGB allocation and keeps the working set in L2 cache.
     ///
     /// For 16-bit/monochrome images, falls back to full-frame conversion.
-    #[cfg(feature = "zencodec")]
     pub fn decode_to_sink(
         &mut self,
         stop: &(impl Stop + ?Sized),
@@ -1312,7 +1295,6 @@ impl ManagedAvifDecoder {
     }
 
     /// Stream a grid image tile-row by tile-row to a sink.
-    #[cfg(feature = "zencodec")]
     fn decode_grid_to_sink(
         &mut self,
         stop: &(impl Stop + ?Sized),
@@ -1346,10 +1328,7 @@ impl ManagedAvifDecoder {
             let mut row_tiles: Vec<PixelBuffer> = Vec::with_capacity(cols);
             for col in 0..cols {
                 let tile_idx = grid_row * cols + col;
-                let tile_data = self
-                    .parser
-                    .tile_data(tile_idx)
-                    .map_err(|e| at!(Error::from(e)))?;
+                let tile_data = self.parser.tile_data(tile_idx).map_err_at(Error::Parse)?;
                 let frame = Self::decode_frame(
                     &mut self.decoder,
                     &tile_data,
@@ -1496,7 +1475,7 @@ impl AnimationDecoder {
             .inner
             .parser
             .frame(self.frame_index)
-            .map_err(|e| at!(Error::from(e)))?;
+            .map_err_at(Error::Parse)?;
 
         let primary_frame = ManagedAvifDecoder::decode_anim_frame(
             &mut self.inner.decoder,

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -152,7 +152,9 @@ pub fn probe(data: &[u8]) -> Result<AvifProbe, ProbeError> {
         return Err(ProbeError::NotAvif);
     }
 
-    let parser = zenavif_parse::AvifParser::from_bytes(data).map_err(|e| match e {
+    // zenavif-parse 0.6.x returns `whereat::At<Error>`; inspect the inner error
+    // (`.error()` borrows `&Error`) to classify the probe failure.
+    let parser = zenavif_parse::AvifParser::from_bytes(data).map_err(|e| match e.error() {
         zenavif_parse::Error::UnexpectedEOF => ProbeError::Truncated,
         zenavif_parse::Error::InvalidData(_) => ProbeError::NotAvif,
         _ => ProbeError::Truncated,
@@ -305,7 +307,6 @@ fn qp_to_quality(qp: u8) -> f32 {
     quality.clamp(1.0, 100.0)
 }
 
-#[cfg(feature = "zencodec")]
 impl zencodec::SourceEncodingDetails for AvifProbe {
     fn source_generic_quality(&self) -> Option<f32> {
         self.quality.as_ref().map(|q| q.estimated_quality)
@@ -418,7 +419,6 @@ mod tests {
                     );
 
                     // Source encoding details trait
-                    #[cfg(feature = "zencodec")]
                     {
                         use zencodec::SourceEncodingDetails;
                         if info.lossless == Some(true) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,7 +53,6 @@ pub enum Error {
     Cancelled(StopReason),
 
     /// Unsupported codec operation
-    #[cfg(feature = "zencodec")]
     #[error(transparent)]
     UnsupportedOperation(#[from] zencodec::UnsupportedOperation),
 }
@@ -64,5 +63,156 @@ impl From<StopReason> for Error {
     }
 }
 
+/// Codec-agnostic error taxonomy (zencodec PR #103). Maps every [`Error`]
+/// variant to exactly one coarse [`zencodec::ErrorCategory`] so a consumer can
+/// route on the category (HTTP status, retry policy, logging) without naming
+/// this enum. `zencodec` is a hard dependency of this crate, so the impl is
+/// unconditional.
+impl zencodec::CategorizedError for Error {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some("zenavif")
+    }
+
+    fn category(&self) -> zencodec::ErrorCategory {
+        use zencodec::ErrorCategory as C;
+        use zencodec::LimitKind as L;
+        match self {
+            // Delegate to the container parser's own taxonomy — the whole point
+            // of zenavif-parse adopting `CategorizedError`: a malformed container
+            // stays `MalformedImage`, a truncated one `UnexpectedEof`, a parser
+            // cap `LimitsExceeded`, etc., without re-classifying here.
+            Self::Parse(e) => e.category(),
+
+            // `Decode` is a catch-all the decode pipeline reuses for many kinds
+            // of failure: rav1d's opaque `code`/`msg`, decoder setup/flush faults
+            // ("failed to create decoder", "failed to flush decoder"), and the
+            // crate's own internal invariant checks ("expected 8-bit planes",
+            // "monochrome should not reach chroma conversion", grid-stitch buffer
+            // failures), alongside a few genuinely-malformed cases (mismatched
+            // grid tile count, missing planes). The plurality are
+            // internal/invariant faults, and the variant carries no structural
+            // signal to split them, so map the whole variant to the conservative
+            // `Internal` rather than blame the input.
+            Self::Decode { .. } => C::Internal,
+
+            // `yuv` is a foreign crate whose error we cannot `impl
+            // CategorizedError` on; a colour-conversion failure here is an
+            // internal pipeline fault, not attributable to the input image.
+            Self::ColorConversion(_) => C::Internal,
+
+            // Encoder (`ravif`) errors are stringly-typed and span config /
+            // limits / internal faults; the wrapping site can't tell which, so
+            // map to `Internal`. The detail string is preserved for diagnostics.
+            Self::Encode(_) => C::Internal,
+
+            // The format is handled, but uses a feature this codec hasn't built.
+            Self::Unsupported(_) => C::UnsupportedImageFeature,
+
+            // A configured image-dimensions cap was hit.
+            Self::ImageTooLarge { .. } => C::LimitsExceeded(L::Pixels),
+
+            // A configured resource cap was hit. The variant carries only a
+            // `String`, not a structured kind, and is a catch-all over
+            // allocation guards / input-size checks / animation sink-writes, so
+            // we report a single representative kind — `Memory`, the dominant
+            // allocation-guard axis. The precise limit stays in `Display`.
+            Self::ResourceLimit(_) => C::LimitsExceeded(L::Memory),
+
+            // Allocation failed (distinct from a configured resource limit).
+            Self::OutOfMemory => C::OutOfMemory,
+
+            // Cooperative cancellation / deadline — delegate to the zencodec
+            // `StopReason` arm (`Cancelled` vs `TimedOut`).
+            Self::Cancelled(reason) => reason.category(),
+
+            // Delegate to the zencodec cause type (`UnsupportedOperation` /
+            // `UnsupportedPixelFormat`).
+            Self::UnsupportedOperation(op) => op.category(),
+        }
+    }
+}
+
 /// Result type for zenavif operations with location tracking
 pub type Result<T, E = whereat::At<Error>> = core::result::Result<T, E>;
+
+#[cfg(test)]
+mod error_category_tests {
+    use super::Error;
+    use zencodec::{CategorizedError, ErrorCategory as C, LimitKind as L};
+
+    #[test]
+    fn error_category_mapping() {
+        assert_eq!(Error::Unsupported("x").codec_name(), Some("zenavif"));
+
+        // Parse errors delegate to zenavif-parse's CategorizedError (PR #17):
+        // a malformed container stays MalformedImage, a truncated one
+        // UnexpectedEof, a parser cap LimitsExceeded.
+        assert_eq!(
+            Error::Parse(zenavif_parse::Error::InvalidData("bad box")).category(),
+            C::MalformedImage
+        );
+        assert_eq!(
+            Error::Parse(zenavif_parse::Error::UnexpectedEOF).category(),
+            C::UnexpectedEof
+        );
+        assert_eq!(
+            Error::Parse(zenavif_parse::Error::ResourceLimitExceeded("megapixels")).category(),
+            C::LimitsExceeded(L::Pixels)
+        );
+
+        // Opaque decoder / color-conversion / encoder faults -> Internal.
+        assert_eq!(
+            Error::Decode {
+                code: -1,
+                msg: "failed to decode"
+            }
+            .category(),
+            C::Internal
+        );
+        assert_eq!(Error::Encode("ravif failed".into()).category(), C::Internal);
+
+        // Format handled, feature not built.
+        assert_eq!(
+            Error::Unsupported("monochrome alpha").category(),
+            C::UnsupportedImageFeature
+        );
+
+        // Limits.
+        assert_eq!(
+            Error::ImageTooLarge {
+                width: 99999,
+                height: 99999
+            }
+            .category(),
+            C::LimitsExceeded(L::Pixels)
+        );
+        assert_eq!(
+            Error::ResourceLimit("peak memory".into()).category(),
+            C::LimitsExceeded(L::Memory)
+        );
+
+        // Allocation.
+        assert_eq!(Error::OutOfMemory.category(), C::OutOfMemory);
+
+        // Cancellation / deadline delegate to StopReason.
+        assert_eq!(
+            Error::Cancelled(enough::StopReason::Cancelled).category(),
+            C::Cancelled
+        );
+        assert_eq!(
+            Error::Cancelled(enough::StopReason::TimedOut).category(),
+            C::TimedOut
+        );
+
+        // UnsupportedOperation delegates to the zencodec cause type.
+        assert_eq!(
+            Error::UnsupportedOperation(zencodec::UnsupportedOperation::AnimationEncode).category(),
+            C::UnsupportedOperation
+        );
+
+        // The blanket `impl CategorizedError for At<E>` forwards both axes.
+        let at_err = whereat::At::from(Error::Unsupported("x"));
+        assert_eq!(at_err.category(), C::UnsupportedImageFeature);
+        assert_eq!(at_err.codec_name(), Some("zenavif"));
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -132,6 +132,25 @@ impl zencodec::CategorizedError for Error {
     }
 }
 
+/// Bridge a bare native [`Error`] into the shared envelope as
+/// `At<zencodec::CodecError>` — the Pattern-B (envelope) error type the zencodec
+/// trait impls return. Used at the trait boundary for errors constructed *in
+/// place* (e.g. `Encoder::reject`, `AnimationFrameDecoder::wrap_sink_error`, the
+/// `push_decoder` sink-error wrap): `.into()` starts the location trace and wraps
+/// the categorized value in one step. An *already-located* `At<Error>` is
+/// converted with [`zencodec::CodecError::of`] instead (it keeps the existing
+/// trace; `From<At<Error>> for At<CodecError>` is impossible under the orphan
+/// rule). `#[track_caller]` records the call site as the trace origin, mirroring
+/// `at!`. The codec name (`"zenavif"`) and category come from this type's
+/// [`zencodec::CategorizedError`] impl, so the envelope is fully populated.
+impl From<Error> for whereat::At<zencodec::CodecError> {
+    #[track_caller]
+    fn from(e: Error) -> Self {
+        use whereat::ErrorAtExt;
+        zencodec::CodecError::of(e.start_at())
+    }
+}
+
 /// Result type for zenavif operations with location tracking
 pub type Result<T, E = whereat::At<Error>> = core::result::Result<T, E>;
 
@@ -211,7 +230,7 @@ mod error_category_tests {
         );
 
         // The blanket `impl CategorizedError for At<E>` forwards both axes.
-        let at_err = whereat::At::from(Error::Unsupported("x"));
+        let at_err = whereat::At::<Error>::from(Error::Unsupported("x"));
         assert_eq!(at_err.category(), C::UnsupportedImageFeature);
         assert_eq!(at_err.codec_name(), Some("zenavif"));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,6 @@ mod auto_tune;
 pub use auto_tune::{AutoTuneError, AutoTuneOptions, QualityTarget};
 
 mod cicp_resolve;
-#[cfg(feature = "zencodec")]
 mod codec;
 mod config;
 mod convert;
@@ -117,11 +116,10 @@ pub(crate) mod yuv_convert_libyuv_simd;
 #[cfg(feature = "encode")]
 use whereat::at;
 
-#[cfg(feature = "zencodec")]
 pub use codec::{
     AvifAnimationFrameDecoder, AvifDecodeJob, AvifDecoder as AvifZenDecoder, AvifDecoderConfig,
 };
-#[cfg(all(feature = "zencodec", feature = "encode"))]
+#[cfg(feature = "encode")]
 pub use codec::{AvifAnimationFrameEncoder, AvifEncodeJob, AvifEncoder, AvifEncoderConfig};
 pub use config::DecoderConfig;
 pub use decode_av1::decode_av1_obu;

--- a/src/sweep.rs
+++ b/src/sweep.rs
@@ -1634,7 +1634,9 @@ mod tests {
         // silently dropping RGB and crippling the picker. Lock that shut.
         let axes = SweepAxes::modes_full();
         assert!(
-            axes.color_models.iter().any(|c| matches!(c, EncodeColorModel::Rgb)),
+            axes.color_models
+                .iter()
+                .any(|c| matches!(c, EncodeColorModel::Rgb)),
             "modes_full must declare the RGB color model"
         );
         let unbudgeted = SweepBuilder::new(axes.clone(), QualityGrid::Explicit(vec![50.0])).plan();

--- a/tests/color_context_decode.rs
+++ b/tests/color_context_decode.rs
@@ -5,8 +5,6 @@
 //! load-bearing reduction propagate it; HDR reconstruction output is
 //! deliberately context-free (no SDR profile describes linear f32).
 
-#![cfg(feature = "zencodec")]
-
 use std::borrow::Cow;
 use zencodec::decode::{Decode as _, DecodeJob as _, DecodeOutput, DecoderConfig as _};
 use zenpixels::{ChannelLayout, PixelDescriptor, PixelFormat};

--- a/tests/cov_zencodec.rs
+++ b/tests/cov_zencodec.rs
@@ -309,3 +309,60 @@ fn orientation_streaming_preserve_keeps_stored_dims() {
         "streaming Preserve must report the intrinsic tag"
     );
 }
+
+// ── Pattern B: ErrorCategory + codec name survive Dyn dispatch (envelope) ────
+
+/// The load-bearing Pattern-B check: drive a malformed AVIF through
+/// [`DynDecoderConfig`](zencodec::decode::DynDecoderConfig), erase the error to
+/// `BoxedError` (`Box<dyn Error + Send + Sync>`), and prove a generic consumer
+/// still recovers the real [`ErrorCategory`](zencodec::ErrorCategory) **and** the
+/// originating codec name. Under Pattern A (`type Error = At<native>`), the boxed
+/// error carries no `CodecError` envelope, so `error_category()` / `codec_error()`
+/// return `None`; under Pattern B (this crate now) they return `Some(..)`.
+#[test]
+fn dyn_dispatch_recovers_category_and_codec_name() {
+    use zencodec::decode::DynDecoderConfig;
+    use zencodec::{CodecError, CodecErrorExt, ErrorCategory};
+
+    // Clearly-malformed input: an `ftyp avif` lead-in followed by garbage, with
+    // no valid box structure after it — long enough that the container parser
+    // actually inspects it rather than rejecting on length alone.
+    let bytes: &[u8] =
+        b"\x00\x00\x00\x18ftypavifmif1miafMA1B garbage-not-a-real-avif-container-payload!!!!";
+
+    // Typed (Pattern B) path: the genuine category zenavif assigns to this input.
+    // Derived at runtime so the assertion is robust to the exact parse variant,
+    // while still proving it is a real classification (not the `Internal`
+    // catch-all). In practice malformed containers land on `MalformedImage` or
+    // `UnexpectedEof`.
+    let typed = AvifDecoderConfig::new()
+        .job()
+        .probe(bytes)
+        .expect_err("malformed input must fail to probe");
+    let expected = typed.error().category();
+    assert_ne!(
+        expected,
+        ErrorCategory::Internal,
+        "a malformed container must get a real input classification, not the \
+         Internal catch-all (got {expected:?})"
+    );
+    assert_eq!(typed.error().codec(), Some("zenavif"));
+
+    // Dyn-dispatch path: erase to `BoxedError` and prove the category + codec
+    // name survive `Box<dyn Error>` erasure.
+    let dyn_cfg: &dyn DynDecoderConfig = &AvifDecoderConfig::new();
+    let erased = dyn_cfg
+        .dyn_job()
+        .probe(bytes)
+        .expect_err("malformed input must fail through dyn dispatch");
+    assert_eq!(
+        erased.error_category(),
+        Some(expected),
+        "ErrorCategory must survive Box<dyn Error> erasure (None under Pattern A)"
+    );
+    assert_eq!(
+        erased.codec_error().and_then(CodecError::codec),
+        Some("zenavif"),
+        "codec name must survive Box<dyn Error> erasure"
+    );
+}

--- a/tests/cov_zencodec.rs
+++ b/tests/cov_zencodec.rs
@@ -7,8 +7,6 @@
 //! leaves pixels in stored orientation, so the adapter is what applies the
 //! transform when the caller asks for it.
 
-#![cfg(feature = "zencodec")]
-
 use std::borrow::Cow;
 
 use zenavif::AvifDecoderConfig;

--- a/tests/gainmap_decode.rs
+++ b/tests/gainmap_decode.rs
@@ -6,7 +6,6 @@
 
 use enough::Unstoppable;
 use zenavif::{DecoderConfig, ManagedAvifDecoder};
-#[cfg(feature = "zencodec")]
 use zencodec::gainmap::GainMapSource;
 
 /// Path to an AVIF file with a gain map (SDR base + gain map for HDR)
@@ -359,7 +358,6 @@ fn gain_map_data_has_valid_obu_structure() {
 /// Gain-map extras are opt-in per the zencodec contract — the default
 /// (`BaseOnly`) decode attaches neither (see
 /// `gain_map_render_base_only_attaches_nothing`).
-#[cfg(feature = "zencodec")]
 #[test]
 fn decode_gain_map_via_zencodec_extras() {
     use zencodec::decode::{Decode as _, DecodeJob as _, DecoderConfig as _};
@@ -395,7 +393,6 @@ fn decode_gain_map_via_zencodec_extras() {
 
 /// The default decode (`BaseOnly`) attaches no gain-map extras at all —
 /// the gain map is ignored, only `ImageInfo` metadata reports its presence.
-#[cfg(feature = "zencodec")]
 #[test]
 fn gain_map_render_base_only_attaches_nothing() {
     use zencodec::decode::{Decode as _, DecodeJob as _, DecoderConfig as _};
@@ -417,7 +414,6 @@ fn gain_map_render_base_only_attaches_nothing() {
 
 /// Decode with `ReconstructHdr` and return the output (full boost when
 /// `target_headroom` is `None`).
-#[cfg(feature = "zencodec")]
 fn decode_reconstruct(data: &[u8], target_headroom: Option<f32>) -> zencodec::decode::DecodeOutput {
     use zencodec::decode::{Decode as _, DecodeJob as _, DecoderConfig as _};
     zenavif::AvifDecoderConfig::new()
@@ -430,7 +426,6 @@ fn decode_reconstruct(data: &[u8], target_headroom: Option<f32>) -> zencodec::de
 }
 
 /// Peak linear value (max over R,G,B of every pixel) of an RgbaF32 buffer.
-#[cfg(feature = "zencodec")]
 fn peak_linear(pixels: &zenpixels::PixelSlice<'_>) -> f32 {
     assert_eq!(
         pixels.descriptor().pixel_format(),
@@ -457,7 +452,6 @@ fn peak_linear(pixels: &zenpixels::PixelSlice<'_>) -> f32 {
 /// applies the gain map via ultrahdr-core. Output is linear f32 RGBA
 /// (1.0 = SDR white), CLL is measured from the reconstructed pixels, and
 /// the gain-map components are still surfaced for transcode use.
-#[cfg(feature = "zencodec")]
 #[test]
 fn gain_map_render_reconstructs_linear_hdr() {
     assert!(
@@ -521,7 +515,6 @@ fn gain_map_render_reconstructs_linear_hdr() {
 /// At `target_headroom = 1.0` (an SDR display) the weight is 0, the gain
 /// is 1.0, and the output is the linearized base — the ISO 21496-1
 /// formula collapses to `sdr + (base_offset - alternate_offset)`.
-#[cfg(feature = "zencodec")]
 #[test]
 fn reconstruct_at_sdr_headroom_matches_linearized_base() {
     use zencodec::decode::{Decode as _, DecodeJob as _, DecoderConfig as _};
@@ -577,7 +570,6 @@ fn reconstruct_at_sdr_headroom_matches_linearized_base() {
 
 /// Reconstruction peak is monotonic in target headroom (weight is
 /// monotonic in display boost): SDR ≤ 2× ≤ full.
-#[cfg(feature = "zencodec")]
 #[test]
 fn reconstruct_headroom_is_monotonic() {
     let data = require_vector!(load_vector(SEINE_SDR_GAINMAP));
@@ -596,7 +588,6 @@ fn reconstruct_headroom_is_monotonic() {
 
 /// Streaming `ReconstructHdr` emits the same pixels as the buffered path
 /// (both run the shared whole-image reconstruction, strip-emitted).
-#[cfg(feature = "zencodec")]
 #[test]
 fn streaming_reconstruct_matches_buffered() {
     use zencodec::decode::{DecodeJob as _, DecoderConfig as _, StreamingDecode as _};
@@ -637,7 +628,6 @@ fn streaming_reconstruct_matches_buffered() {
     assert_eq!(rows_seen, h, "stream must cover every row exactly once");
 }
 
-#[cfg(feature = "zencodec")]
 #[test]
 fn decode_no_gain_map_extras_on_normal_image() {
     use zencodec::decode::{Decode as _, DecodeJob as _, DecoderConfig as _};

--- a/tests/mono_decode.rs
+++ b/tests/mono_decode.rs
@@ -8,8 +8,6 @@
 //! expansion kernel as the RGB path, so `gray[i] == rgb[i].r` exactly —
 //! any drift between the two paths is a bug in one of them.
 
-#![cfg(feature = "zencodec")]
-
 use std::borrow::Cow;
 use zencodec::decode::{Decode as _, DecodeJob as _, DecodeOutput, DecoderConfig as _};
 use zenpixels::{ChannelLayout, PixelDescriptor, PixelFormat};


### PR DESCRIPTION
## Adopt the `zencodec` `CategorizedError` taxonomy (PR #103, final API) + make `zencodec` required

Two coupled changes:

### 1. `CategorizedError` taxonomy (final #103 API)

`Error` now `impl zencodec::CategorizedError`, mapping every variant to one
coarse `zencodec::ErrorCategory` so consumers route on the category (HTTP
status, retry policy, logging) without naming the enum.

- `fn codec_name(&self) -> Option<&'static str>` returns `Some("zenavif")` — a
  `&self` **method** (the draft used a `CODEC_NAME` const; the final trait uses a
  method so it stays dyn-compatible).

| `Error` variant | `ErrorCategory` |
|---|---|
| `Parse(zenavif_parse::Error)` | **delegates** to `e.category()` (zenavif-parse #17) |
| `Unsupported(&str)` | `UnsupportedImageFeature` |
| `ImageTooLarge { .. }` | `LimitsExceeded(Pixels)` |
| `ResourceLimit(String)` | `LimitsExceeded(Memory)` |
| `OutOfMemory` | `OutOfMemory` |
| `Cancelled(StopReason)` | `r.category()` → `Cancelled` / `TimedOut` |
| `UnsupportedOperation(op)` | `op.category()` → `UnsupportedOperation` / `UnsupportedPixelFormat` |
| `Decode { code, msg }` | `Internal` |
| `ColorConversion(yuv::YuvError)` | `Internal` |
| `Encode(String)` | `Internal` |

**Judgment call — `Decode` → `Internal` (not `MalformedImage`):** `Decode` is a
grab-bag the decode pipeline reuses for many failures. Surveying its ~25
construction sites, the plurality are decoder setup/flush faults and internal
invariant checks ("failed to create decoder", "failed to flush decoder",
"expected 8-bit planes", "monochrome should not reach chroma conversion",
grid-stitch buffer failures), with only some genuinely-malformed cases
(mismatched grid tile count, missing planes). With only a `code`/`msg` pair and
no structural signal to split them, `Internal` is the conservative best single
category — mapping the whole variant to `MalformedImage` would falsely blame the
input for decoder-internal faults. `ColorConversion` wraps the foreign
`yuv::YuvError` (can't `impl` on it; pipeline-internal) and `Encode` is a
stringly `ravif` catch-all spanning config/internal — both `Internal`.

### 2. `zencodec` is now a required (non-optional) dependency

The optional `zencodec` cargo feature is removed; the codec-trait integration
(the `codec` module implementing `Encoder`/`Decoder` + `SourceEncodingDetails`,
the `CategorizedError` impl, and `From<zencodec::AllocPreference>`) is always
built. `ultrahdr-core` (gain-map `ReconstructHdr` math, previously pulled only by
the `zencodec` feature) becomes a hard dep for the same reason. Every
`#[cfg(feature = "zencodec")]` in `src/` is flipped to unconditional.

The `cov_zencodec` / `color_context_decode` / `mono_decode` / `gainmap_decode`
integration tests were `#![cfg(feature = "zencodec")]`-gated; with the feature
gone they would otherwise be silently excluded forever, so they are ungated and
now run under default `cargo test`. CI:
- drops the now-redundant `--features zencodec` test/check/clippy steps (the
  default steps now cover that code, since it's unconditional);
- provisions the downloaded AVIF vectors (`scripts/download-*.sh`) in the `i686`
  and `coverage` jobs, which now run those decode tests (they read downloaded
  link-u / av1-avif vectors via hard `.expect()`). No test-body skips were added.

### Incidental: zenavif-parse 0.6.x `whereat::At<Error>` migration

Consuming zenavif-parse's `CategorizedError` requires patching to its
`caterr-categorized-error` branch (v0.6.3), whose parser entry points return
`whereat::At<Error>`. zenavif's parse-error boundaries (`decoder_managed.rs`,
`decoder.rs`, `detect.rs`) switch from `at!(Error::Parse(e))` to the
trace-preserving `ResultAtExt::map_err_at(Error::Parse)` / `At::map_error(...)`
(and `e.error()` for the probe-classification match). Decode output is unchanged
(error-path only). The declared `zenavif-parse` dep is bumped to `0.6.3`.

### Temporary patch

```toml
[patch.crates-io]
zencodec = { git = "https://github.com/imazen/zencodec", branch = "cancellation-classification-99" }
zenavif-parse = { git = "https://github.com/imazen/zenavif-parse", branch = "caterr-categorized-error" }
```

Remove both patches and bump the version deps once `zencodec 0.1.26` and the
`zenavif-parse` `CategorizedError` release ship.

### Gate results (local, `run-heavy --mem 14G --jobs 6`)

- `cargo fmt --check` — clean
- `cargo check --all-targets` — ok (codec module + ungated tests + ultrahdr-core all compile)
- `cargo clippy --all-targets` — clean
- `cargo test --no-fail-fast` — lib (65 + 13) + doctests pass, **including the
  `error::error_category_tests::error_category_mapping` test** (every variant +
  `At<E>` forwarding + `codec_name()`). The only local failures are 10 corpus
  tests in `cov_zencodec` / `color_context_decode` that read downloaded
  `tests/vectors` not present in the local worktree (CI downloads them — now also
  in i686 + coverage). No logic/assertion failures.

### CI status — note the pre-existing i686 failure (NOT from this PR)

CI is green on every job **except `Test (i686 cross)`**, which fails on the
**pre-existing** lib test `yuv_convert::tests::yuv422_to_rgb8_byte_identical_to_reference`
(`src/yuv_convert.rs:1594`) — an i686 floating-point/SIMD byte-divergence between
the optimized YUV422→RGB8 kernel and its scalar reference. This is **not
introduced by this PR**: `main`'s own CI (run 28294230043 on `a5697e0a`, this
PR's parent) fails the identical test at the identical line, and `main` has been
red for several runs. This PR does not touch `yuv_convert.rs`. It actually runs
*more* lib tests on i686 than `main` (63 passing vs `main`'s 51, since the codec
module is now always built) and adds `error_category_mapping` (passes on i686) —
only the pre-existing yuv test still fails. As a bonus, `main`'s failing
`Clippy (default)` job is **green** on this PR. The i686 yuv determinism bug is
real but orthogonal to the error taxonomy and is left for a separate fix (not
relaxed/ignored here).
